### PR TITLE
Use the right PyQt4/PySide QtGui classes in QtWidgets and QtGui

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -8,8 +8,8 @@
 
 """
 Provides QtGui classes and functions.
-.. warning:: Only PyQt4/PySide Gui classes compatible with PyQt5 are exposed
-    here. Therefore, you need to treat/use this package as if it were
+.. warning:: Only PyQt4/PySide Gui classes compatible with PyQt5.QtGui are
+    exposed here. Therefore, you need to treat/use this package as if it were
     the ``PyQt5.QtGui`` module.
 """
 

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -8,7 +8,7 @@
 
 """
 Provides QtGui classes and functions.
-.. warning:: Only PyQt4/PySide Gui classes compatible with PyQt5.QtGui are
+.. warning:: Only PyQt4/PySide QtGui classes compatible with PyQt5.QtGui are
     exposed here. Therefore, you need to treat/use this package as if it were
     the ``PyQt5.QtGui`` module.
 """

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -25,6 +25,7 @@ from qtpy import PythonQtError
 if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtGui import *
 elif os.environ[QT_API] in PYQT4_API:
+    from PyQt4.Qt import QKeySequence, QTextCursor
     from PyQt4.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
                              QBrush, QClipboard, QCloseEvent, QColor,
                              QConicalGradient, QContextMenuEvent, QCursor,
@@ -36,7 +37,7 @@ elif os.environ[QT_API] in PYQT4_API:
                              QHideEvent, QHoverEvent, QIcon, QIconDragEvent,
                              QIconEngine, QImage, QImageIOHandler, QImageReader,
                              QImageWriter, QInputEvent, QInputMethodEvent,
-                             QKeyEvent, QKeySequence, QLinearGradient,
+                             QKeyEvent, QLinearGradient,
                              QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2,
                              QMatrix3x3, QMatrix3x4, QMatrix4x2, QMatrix4x3,
                              QMatrix4x4, QMouseEvent, QMoveEvent, QMovie,
@@ -50,7 +51,7 @@ elif os.environ[QT_API] in PYQT4_API:
                              QStandardItem, QStandardItemModel, QStaticText,
                              QStatusTipEvent, QSyntaxHighlighter, QTabletEvent,
                              QTextBlock, QTextBlockFormat, QTextBlockGroup,
-                             QTextBlockUserData, QTextCharFormat, QTextCursor,
+                             QTextBlockUserData, QTextCharFormat,
                              QTextDocument, QTextDocumentFragment,
                              QTextDocumentWriter, QTextFormat, QTextFragment,
                              QTextFrame, QTextFrameFormat, QTextImageFormat,

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -71,7 +71,7 @@ elif os.environ[QT_API] in PYSIDE_API:
                               QDragEnterEvent, QDragLeaveEvent, QDragMoveEvent,
                               QDropEvent, QFileOpenEvent, QFocusEvent, QFont,
                               QFontDatabase, QFontInfo, QFontMetrics,
-                              QFontMetricsF, QGlyphRun, QGradient, QHelpEvent,
+                              QFontMetricsF, QGradient, QHelpEvent,
                               QHideEvent, QHoverEvent, QIcon, QIconDragEvent,
                               QIconEngine, QImage, QImageIOHandler, QImageReader,
                               QImageWriter, QInputEvent, QInputMethodEvent,
@@ -83,15 +83,15 @@ elif os.environ[QT_API] in PYSIDE_API:
                               QPaintEvent, QPainter, QPainterPath,
                               QPainterPathStroker, QPalette, QPen, QPicture,
                               QPictureIO, QPixmap, QPixmapCache, QPolygon,
-                              QPolygonF, QQuaternion, QRadialGradient, QRawFont,
+                              QPolygonF, QQuaternion, QRadialGradient,
                               QRegExpValidator, QRegion, QResizeEvent,
                               QSessionManager, QShortcutEvent, QShowEvent,
-                              QStandardItem, QStandardItemModel, QStaticText,
+                              QStandardItem, QStandardItemModel,
                               QStatusTipEvent, QSyntaxHighlighter, QTabletEvent,
                               QTextBlock, QTextBlockFormat, QTextBlockGroup,
                               QTextBlockUserData, QTextCharFormat, QTextCursor,
                               QTextDocument, QTextDocumentFragment,
-                              QTextDocumentWriter, QTextFormat, QTextFragment,
+                              QTextFormat, QTextFragment,
                               QTextFrame, QTextFrameFormat, QTextImageFormat,
                               QTextInlineObject, QTextItem, QTextLayout,
                               QTextLength, QTextLine, QTextList, QTextListFormat,
@@ -101,8 +101,7 @@ elif os.environ[QT_API] in PYSIDE_API:
                               QValidator, QVector2D, QVector3D, QVector4D,
                               QWhatsThisClickedEvent, QWheelEvent,
                               QWindowStateChangeEvent, qAlpha, qBlue,
-                              qFuzzyCompare, qGray, qGreen, qIsGray, qRed, qRgb,
-                              qRgba)
+                              qGray, qGreen, qIsGray, qRed, qRgb, qRgba)
 else:
     raise PythonQtError('No Qt bindings could be found')
 

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -8,9 +8,9 @@
 
 """
 Provides QtGui classes and functions.
-.. warning:: All PyQt4/PySide gui classes are exposed but when you use
-    PyQt5, those classes are not available. Therefore, you should treat/use
-    this package as if it was ``PyQt5.QtGui`` module.
+.. warning:: Only PyQt4/PySide Gui classes compatible with PyQt5 are exposed
+    here. Therefore, you need to treat/use this package as if it were
+    the ``PyQt5.QtGui`` module.
 """
 
 import os
@@ -24,9 +24,85 @@ from qtpy import PythonQtError
 if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtGui import *                                 # analysis:ignore
 elif os.environ[QT_API] in PYQT4_API:
-    from PyQt4.QtGui import *                                 # analysis:ignore
+    from PyQt4.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
+                             QBrush, QClipboard, QCloseEvent, QColor,
+                             QConicalGradient, QContextMenuEvent, QCursor,
+                             QDesktopServices, QDoubleValidator, QDrag,
+                             QDragEnterEvent, QDragLeaveEvent, QDragMoveEvent,
+                             QDropEvent, QFileOpenEvent, QFocusEvent, QFont,
+                             QFontDatabase, QFontInfo, QFontMetrics,
+                             QFontMetricsF, QGlyphRun, QGradient, QHelpEvent,
+                             QHideEvent, QHoverEvent, QIcon, QIconDragEvent,
+                             QIconEngine, QImage, QImageIOHandler, QImageReader,
+                             QImageWriter, QInputEvent, QInputMethodEvent,
+                             QKeyEvent, QKeySequence, QLinearGradient,
+                             QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2,
+                             QMatrix3x3, QMatrix3x4, QMatrix4x2, QMatrix4x3,
+                             QMatrix4x4, QMouseEvent, QMoveEvent, QMovie,
+                             QPaintDevice, QPaintEngine, QPaintEngineState,
+                             QPaintEvent, QPainter, QPainterPath,
+                             QPainterPathStroker, QPalette, QPen, QPicture,
+                             QPictureIO, QPixmap, QPixmapCache, QPolygon,
+                             QPolygonF, QQuaternion, QRadialGradient, QRawFont,
+                             QRegExpValidator, QRegion, QResizeEvent,
+                             QSessionManager, QShortcutEvent, QShowEvent,
+                             QStandardItem, QStandardItemModel, QStaticText,
+                             QStatusTipEvent, QSyntaxHighlighter, QTabletEvent,
+                             QTextBlock, QTextBlockFormat, QTextBlockGroup,
+                             QTextBlockUserData, QTextCharFormat, QTextCursor,
+                             QTextDocument, QTextDocumentFragment,
+                             QTextDocumentWriter, QTextFormat, QTextFragment,
+                             QTextFrame, QTextFrameFormat, QTextImageFormat,
+                             QTextInlineObject, QTextItem, QTextLayout,
+                             QTextLength, QTextLine, QTextList, QTextListFormat,
+                             QTextObject, QTextObjectInterface, QTextOption,
+                             QTextTable, QTextTableCell, QTextTableCellFormat,
+                             QTextTableFormat, QTouchEvent, QTransform,
+                             QValidator, QVector2D, QVector3D, QVector4D,
+                             QWhatsThisClickedEvent, QWheelEvent,
+                             QWindowStateChangeEvent, qAlpha, qBlue,
+                             qFuzzyCompare, qGray, qGreen, qIsGray, qRed, qRgb,
+                             qRgba)
 elif os.environ[QT_API] in PYSIDE_API:
-    from PySide.QtGui import *                                # analysis:ignore
+    from PySide.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
+                              QBrush, QClipboard, QCloseEvent, QColor,
+                              QConicalGradient, QContextMenuEvent, QCursor,
+                              QDesktopServices, QDoubleValidator, QDrag,
+                              QDragEnterEvent, QDragLeaveEvent, QDragMoveEvent,
+                              QDropEvent, QFileOpenEvent, QFocusEvent, QFont,
+                              QFontDatabase, QFontInfo, QFontMetrics,
+                              QFontMetricsF, QGlyphRun, QGradient, QHelpEvent,
+                              QHideEvent, QHoverEvent, QIcon, QIconDragEvent,
+                              QIconEngine, QImage, QImageIOHandler, QImageReader,
+                              QImageWriter, QInputEvent, QInputMethodEvent,
+                              QKeyEvent, QKeySequence, QLinearGradient,
+                              QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2,
+                              QMatrix3x3, QMatrix3x4, QMatrix4x2, QMatrix4x3,
+                              QMatrix4x4, QMouseEvent, QMoveEvent, QMovie,
+                              QPaintDevice, QPaintEngine, QPaintEngineState,
+                              QPaintEvent, QPainter, QPainterPath,
+                              QPainterPathStroker, QPalette, QPen, QPicture,
+                              QPictureIO, QPixmap, QPixmapCache, QPolygon,
+                              QPolygonF, QQuaternion, QRadialGradient, QRawFont,
+                              QRegExpValidator, QRegion, QResizeEvent,
+                              QSessionManager, QShortcutEvent, QShowEvent,
+                              QStandardItem, QStandardItemModel, QStaticText,
+                              QStatusTipEvent, QSyntaxHighlighter, QTabletEvent,
+                              QTextBlock, QTextBlockFormat, QTextBlockGroup,
+                              QTextBlockUserData, QTextCharFormat, QTextCursor,
+                              QTextDocument, QTextDocumentFragment,
+                              QTextDocumentWriter, QTextFormat, QTextFragment,
+                              QTextFrame, QTextFrameFormat, QTextImageFormat,
+                              QTextInlineObject, QTextItem, QTextLayout,
+                              QTextLength, QTextLine, QTextList, QTextListFormat,
+                              QTextObject, QTextObjectInterface, QTextOption,
+                              QTextTable, QTextTableCell, QTextTableCellFormat,
+                              QTextTableFormat, QTouchEvent, QTransform,
+                              QValidator, QVector2D, QVector3D, QVector4D,
+                              QWhatsThisClickedEvent, QWheelEvent,
+                              QWindowStateChangeEvent, qAlpha, qBlue,
+                              qFuzzyCompare, qGray, qGreen, qIsGray, qRed, qRgb,
+                              qRgba)
 else:
     raise PythonQtError('No Qt bindings could be found')
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -26,6 +26,8 @@ if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtWidgets import *
 elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtGui import *
+    QStyleOptionViewItem = QStyleOptionViewItemV4
+
     del (QAbstractTextDocumentLayout, QActionEvent, QBitmap, QBrush, QClipboard,
          QCloseEvent, QColor, QConicalGradient, QContextMenuEvent, QCursor,
          QDesktopServices, QDoubleValidator, QDrag, QDragEnterEvent,
@@ -59,6 +61,8 @@ elif os.environ[QT_API] in PYQT4_API:
          QPrintPreviewDialog, QPrintPreviewWidget, QPrinter, QPrinterInfo)
 elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *
+    QStyleOptionViewItem = QStyleOptionViewItemV4
+
     del (QAbstractTextDocumentLayout, QActionEvent, QBitmap, QBrush, QClipboard,
          QCloseEvent, QColor, QConicalGradient, QContextMenuEvent, QCursor,
          QDesktopServices, QDoubleValidator, QDrag, QDragEnterEvent,

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -53,6 +53,9 @@ elif os.environ[QT_API] in PYQT4_API:
          QValidator, QVector2D, QVector3D, QVector4D, QWhatsThisClickedEvent,
          QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qFuzzyCompare,
          qGray, qGreen, qIsGray, qRed, qRgb, qRgba)
+
+    del (QAbstractPrintDialog, QPageSetupDialog, QPrintDialog, QPrintEngine,
+         QPrintPreviewDialog, QPrintPreviewWidget, QPrinter, QPrinterInfo)
 elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *                                # analysis:ignore
     del (QAbstractTextDocumentLayout, QActionEvent, QBitmap, QBrush, QClipboard,
@@ -83,6 +86,9 @@ elif os.environ[QT_API] in PYSIDE_API:
          QValidator, QVector2D, QVector3D, QVector4D, QWhatsThisClickedEvent,
          QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qGray, qGreen,
          qIsGray, qRed, qRgb, qRgba)
+
+    del (QAbstractPrintDialog, QPageSetupDialog, QPrintDialog, QPrintEngine,
+         QPrintPreviewDialog, QPrintPreviewWidget, QPrinter, QPrinterInfo)
 else:
     raise PythonQtError('No Qt bindings could be found')
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -25,33 +25,6 @@ if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtWidgets import *                             # analysis:ignore
 elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtGui import *                                 # analysis:ignore
-    from PyQt4.QtGui import QFileDialog as OldFileDialog
-
-    class QFileDialog(OldFileDialog):
-
-        @staticmethod
-        def getOpenFileName(parent=None, caption='', directory='',
-                            filter='', selectedFilter='',
-                            options=OldFileDialog.Options()):
-            return OldFileDialog.getOpenFileNameAndFilter(
-                parent, caption, directory, filter, selectedFilter,
-                options)
-
-        @staticmethod
-        def getOpenFileNames(parent=None, caption='', directory='',
-                             filter='', selectedFilter='',
-                             options=OldFileDialog.Options()):
-            return OldFileDialog.getOpenFileNamesAndFilter(
-                parent, caption, directory, filter, selectedFilter,
-                options)
-
-        @staticmethod
-        def getSaveFileName(parent=None, caption='', directory='',
-                            filter='', selectedFilter='',
-                            options=OldFileDialog.Options()):
-            return OldFileDialog.getSaveFileNameAndFilter(
-                parent, caption, directory, filter, selectedFilter,
-                options)
 elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *                                # analysis:ignore
 else:

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -60,7 +60,7 @@ elif os.environ[QT_API] in PYSIDE_API:
          QDesktopServices, QDoubleValidator, QDrag, QDragEnterEvent,
          QDragLeaveEvent, QDragMoveEvent, QDropEvent, QFileOpenEvent,
          QFocusEvent, QFont, QFontDatabase, QFontInfo, QFontMetrics,
-         QFontMetricsF, QGlyphRun, QGradient, QHelpEvent, QHideEvent,
+         QFontMetricsF, QGradient, QHelpEvent, QHideEvent,
          QHoverEvent, QIcon, QIconDragEvent, QIconEngine, QImage,
          QImageIOHandler, QImageReader, QImageWriter, QInputEvent,
          QInputMethodEvent, QKeyEvent, QKeySequence, QLinearGradient,
@@ -69,20 +69,20 @@ elif os.environ[QT_API] in PYSIDE_API:
          QMoveEvent, QMovie, QPaintDevice, QPaintEngine, QPaintEngineState,
          QPaintEvent, QPainter, QPainterPath, QPainterPathStroker, QPalette,
          QPen, QPicture, QPictureIO, QPixmap, QPixmapCache, QPolygon,
-         QPolygonF, QQuaternion, QRadialGradient, QRawFont, QRegExpValidator,
+         QPolygonF, QQuaternion, QRadialGradient, QRegExpValidator,
          QRegion, QResizeEvent, QSessionManager, QShortcutEvent, QShowEvent,
-         QStandardItem, QStandardItemModel, QStaticText, QStatusTipEvent,
+         QStandardItem, QStandardItemModel, QStatusTipEvent,
          QSyntaxHighlighter, QTabletEvent, QTextBlock, QTextBlockFormat,
          QTextBlockGroup, QTextBlockUserData, QTextCharFormat, QTextCursor,
-         QTextDocument, QTextDocumentFragment, QTextDocumentWriter,
+         QTextDocument, QTextDocumentFragment,
          QTextFormat, QTextFragment, QTextFrame, QTextFrameFormat,
          QTextImageFormat, QTextInlineObject, QTextItem, QTextLayout,
          QTextLength, QTextLine, QTextList, QTextListFormat, QTextObject,
          QTextObjectInterface, QTextOption, QTextTable, QTextTableCell,
          QTextTableCellFormat, QTextTableFormat, QTouchEvent, QTransform,
          QValidator, QVector2D, QVector3D, QVector4D, QWhatsThisClickedEvent,
-         QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qFuzzyCompare,
-         qGray, qGreen, qIsGray, qRed, qRgb, qRgba)
+         QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qGray, qGreen,
+         qIsGray, qRed, qRgb, qRgba)
 else:
     raise PythonQtError('No Qt bindings could be found')
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -8,9 +8,9 @@
 
 """
 Provides widget classes and functions.
-.. warning:: Only PyQt4/PySide Gui classes compatible with PyQt5.QtWidgets are
-    exposed here. Therefore, you need to treat/use this package as if it were
-    the ``PyQt5.QtWidgets`` module.
+.. warning:: Only PyQt4/PySide QtGui classes compatible with PyQt5.QtWidgets
+    are exposed here. Therefore, you need to treat/use this package as if it
+    were the ``PyQt5.QtWidgets`` module.
 """
 
 import os

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -8,9 +8,9 @@
 
 """
 Provides widget classes and functions.
-.. warning:: All PyQt4/PySide gui classes are exposed but when you use
-    PyQt5, those classes are not available. Therefore, you should treat/use
-    this package as if it was ``PyQt5.QtWidgets`` module.
+.. warning:: Only PyQt4/PySide Gui classes compatible with PyQt5.QtWidgets are
+    exposed here. Therefore, you need to treat/use this package as if it were
+    the ``PyQt5.QtWidgets`` module.
 """
 
 import os
@@ -25,8 +25,64 @@ if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtWidgets import *                             # analysis:ignore
 elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtGui import *                                 # analysis:ignore
+    del (QAbstractTextDocumentLayout, QActionEvent, QBitmap, QBrush, QClipboard,
+         QCloseEvent, QColor, QConicalGradient, QContextMenuEvent, QCursor,
+         QDesktopServices, QDoubleValidator, QDrag, QDragEnterEvent,
+         QDragLeaveEvent, QDragMoveEvent, QDropEvent, QFileOpenEvent,
+         QFocusEvent, QFont, QFontDatabase, QFontInfo, QFontMetrics,
+         QFontMetricsF, QGlyphRun, QGradient, QHelpEvent, QHideEvent,
+         QHoverEvent, QIcon, QIconDragEvent, QIconEngine, QImage,
+         QImageIOHandler, QImageReader, QImageWriter, QInputEvent,
+         QInputMethodEvent, QKeyEvent, QKeySequence, QLinearGradient,
+         QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2, QMatrix3x3,
+         QMatrix3x4, QMatrix4x2, QMatrix4x3, QMatrix4x4, QMouseEvent,
+         QMoveEvent, QMovie, QPaintDevice, QPaintEngine, QPaintEngineState,
+         QPaintEvent, QPainter, QPainterPath, QPainterPathStroker, QPalette,
+         QPen, QPicture, QPictureIO, QPixmap, QPixmapCache, QPolygon,
+         QPolygonF, QQuaternion, QRadialGradient, QRawFont, QRegExpValidator,
+         QRegion, QResizeEvent, QSessionManager, QShortcutEvent, QShowEvent,
+         QStandardItem, QStandardItemModel, QStaticText, QStatusTipEvent,
+         QSyntaxHighlighter, QTabletEvent, QTextBlock, QTextBlockFormat,
+         QTextBlockGroup, QTextBlockUserData, QTextCharFormat, QTextCursor,
+         QTextDocument, QTextDocumentFragment, QTextDocumentWriter,
+         QTextFormat, QTextFragment, QTextFrame, QTextFrameFormat,
+         QTextImageFormat, QTextInlineObject, QTextItem, QTextLayout,
+         QTextLength, QTextLine, QTextList, QTextListFormat, QTextObject,
+         QTextObjectInterface, QTextOption, QTextTable, QTextTableCell,
+         QTextTableCellFormat, QTextTableFormat, QTouchEvent, QTransform,
+         QValidator, QVector2D, QVector3D, QVector4D, QWhatsThisClickedEvent,
+         QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qFuzzyCompare,
+         qGray, qGreen, qIsGray, qRed, qRgb, qRgba)
 elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *                                # analysis:ignore
+    del (QAbstractTextDocumentLayout, QActionEvent, QBitmap, QBrush, QClipboard,
+         QCloseEvent, QColor, QConicalGradient, QContextMenuEvent, QCursor,
+         QDesktopServices, QDoubleValidator, QDrag, QDragEnterEvent,
+         QDragLeaveEvent, QDragMoveEvent, QDropEvent, QFileOpenEvent,
+         QFocusEvent, QFont, QFontDatabase, QFontInfo, QFontMetrics,
+         QFontMetricsF, QGlyphRun, QGradient, QHelpEvent, QHideEvent,
+         QHoverEvent, QIcon, QIconDragEvent, QIconEngine, QImage,
+         QImageIOHandler, QImageReader, QImageWriter, QInputEvent,
+         QInputMethodEvent, QKeyEvent, QKeySequence, QLinearGradient,
+         QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2, QMatrix3x3,
+         QMatrix3x4, QMatrix4x2, QMatrix4x3, QMatrix4x4, QMouseEvent,
+         QMoveEvent, QMovie, QPaintDevice, QPaintEngine, QPaintEngineState,
+         QPaintEvent, QPainter, QPainterPath, QPainterPathStroker, QPalette,
+         QPen, QPicture, QPictureIO, QPixmap, QPixmapCache, QPolygon,
+         QPolygonF, QQuaternion, QRadialGradient, QRawFont, QRegExpValidator,
+         QRegion, QResizeEvent, QSessionManager, QShortcutEvent, QShowEvent,
+         QStandardItem, QStandardItemModel, QStaticText, QStatusTipEvent,
+         QSyntaxHighlighter, QTabletEvent, QTextBlock, QTextBlockFormat,
+         QTextBlockGroup, QTextBlockUserData, QTextCharFormat, QTextCursor,
+         QTextDocument, QTextDocumentFragment, QTextDocumentWriter,
+         QTextFormat, QTextFragment, QTextFrame, QTextFrameFormat,
+         QTextImageFormat, QTextInlineObject, QTextItem, QTextLayout,
+         QTextLength, QTextLine, QTextList, QTextListFormat, QTextObject,
+         QTextObjectInterface, QTextOption, QTextTable, QTextTableCell,
+         QTextTableCellFormat, QTextTableFormat, QTouchEvent, QTransform,
+         QValidator, QVector2D, QVector3D, QVector4D, QWhatsThisClickedEvent,
+         QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qFuzzyCompare,
+         qGray, qGreen, qIsGray, qRed, qRgb, qRgba)
 else:
     raise PythonQtError('No Qt bindings could be found')
 


### PR DESCRIPTION
Instead of importing all of `{PyQt4, Pyside}.QtGui` in those modules, now we import exactly what's needed to maintain compatibility with PyQt5.