### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -116,7 +116,7 @@ if API in PYQT4_API:
         is_pyqt46 = __version__.startswith('4.6')
         import sip
         try:
-            API_NAME += (" (API v%d)" % sip.getapi('QString'))
+            API_NAME += (" (API v{0:d})".format(sip.getapi('QString')))
         except AttributeError:
             pass
 

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -116,7 +116,7 @@ if API in PYQT4_API:
         is_pyqt46 = __version__.startswith('4.6')
         import sip
         try:
-            API_NAME += (" (API v{0:d})".format(sip.getapi('QString')))
+            API_NAME += (" (API v{0})".format(sip.getapi('QString')))
         except AttributeError:
             pass
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,7 @@ os.environ['QT_API'] = os.environ['USE_QT_API'].lower()
 
 from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
 
-print('Qt version:{0!s}'.format(QtCore.__version__))
+print('Qt version:{0}'.format(QtCore.__version__))
 print(QtCore.QEvent)
 print(QtGui.QPainter)
 print(QtWidgets.QWidget)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,7 @@ os.environ['QT_API'] = os.environ['USE_QT_API'].lower()
 
 from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
 
-print('Qt version:%s' % QtCore.__version__)
+print('Qt version:{0!s}'.format(QtCore.__version__))
 print(QtCore.QEvent)
 print(QtGui.QPainter)
 print(QtWidgets.QWidget)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:spyder-ide:qtpy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:spyder-ide:qtpy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)