### PR TITLE
Use ci-helpers (from Astropy) for CI and enable AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ matrix:
 before_install:
   # Test environments for different Qt bindings
   - if [[ "$USE_QT_API" == "PyQt5" ]]; then
-      export CONDA_DEPENDENCIES='qt5 pyqt5'$CONDA_DEPENDENCIES
-      export CONDA_CHANNELS='spyder-ide'
+      export CONDA_DEPENDENCIES='qt5 pyqt5'$CONDA_DEPENDENCIES;
+      export CONDA_CHANNELS='spyder-ide';
     elif [[ "$USE_QT_API" == "PyQt4" ]]; then
-      export CONDA_DEPENDENCIES='qt pyqt'$CONDA_DEPENDENCIES
+      export CONDA_DEPENDENCIES='qt pyqt'$CONDA_DEPENDENCIES;
     elif [[ "$USE_QT_API" == "PySide" ]]; then
-      export CONDA_DEPENDENCIES='qt pyside'$CONDA_DEPENDENCIES
+      export CONDA_DEPENDENCIES='qt pyside'$CONDA_DEPENDENCIES;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,22 @@ env:
     - SETUP_XVFB=True
     - CONDA_DEPENDENCIES='pytest'
   matrix:
-    - env: PYTHON_VERSION=2.7 USE_QT_API=PyQt5
-    - env: PYTHON_VERSION=2.7 USE_QT_API=PyQt4
-    - env: PYTHON_VERSION=2.7 USE_QT_API=PySide
-    - env: PYTHON_VERSION=3.4 USE_QT_API=PyQt4
-    - env: PYTHON_VERSION=3.5 USE_QT_API=PyQt4
-    - env: PYTHON_VERSION=3.5 USE_QT_API=PyQt5
+    - PYTHON_VERSION=2.7 USE_QT_API=PyQt5
+    - PYTHON_VERSION=2.7 USE_QT_API=PyQt4
+    - PYTHON_VERSION=2.7 USE_QT_API=PySide
+    - PYTHON_VERSION=3.4 USE_QT_API=PyQt4
+    - PYTHON_VERSION=3.5 USE_QT_API=PyQt4
+    - PYTHON_VERSION=3.5 USE_QT_API=PyQt5
 
 before_install:
   # Test environments for different Qt bindings
   - if [[ "$USE_QT_API" == "PyQt5" ]]; then
-      export CONDA_DEPENDENCIES='qt5 pyqt5'$CONDA_DEPENDENCIES;
+      export CONDA_DEPENDENCIES='qt5 pyqt5 '$CONDA_DEPENDENCIES;
       export CONDA_CHANNELS='spyder-ide';
     elif [[ "$USE_QT_API" == "PyQt4" ]]; then
-      export CONDA_DEPENDENCIES='qt pyqt'$CONDA_DEPENDENCIES;
+      export CONDA_DEPENDENCIES='qt pyqt '$CONDA_DEPENDENCIES;
     elif [[ "$USE_QT_API" == "PySide" ]]; then
-      export CONDA_DEPENDENCIES='qt pyside'$CONDA_DEPENDENCIES;
+      export CONDA_DEPENDENCIES='qt pyside '$CONDA_DEPENDENCIES;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
 language: c
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,12 @@ env:
     - SETUP_XVFB=True
     - CONDA_DEPENDENCIES='pytest'
   matrix:
-    - python: "2.7"
-      env: USE_QT_API=PyQt5
-    - python: "2.7"
-      env: USE_QT_API=PyQt4
-    - python: "2.7"
-      env: USE_QT_API=PySide
-    - python: "3.4"
-      env: USE_QT_API=PyQt4
-    - python: "3.5"
-      env: USE_QT_API=PyQt5
-    - python: "3.5"
-      env: USE_QT_API=PyQt4
+    - env: PYTHON_VERSION=2.7 USE_QT_API=PyQt5
+    - env: PYTHON_VERSION=2.7 USE_QT_API=PyQt4
+    - env: PYTHON_VERSION=2.7 USE_QT_API=PySide
+    - env: PYTHON_VERSION=3.4 USE_QT_API=PyQt4
+    - env: PYTHON_VERSION=3.5 USE_QT_API=PyQt4
+    - env: PYTHON_VERSION=3.5 USE_QT_API=PyQt5
 
 before_install:
   # Test environments for different Qt bindings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,72 +1,49 @@
-language: python
+language: c
+
 sudo: false
+
+os:
+  - linux
+  - osx
 
 env:
   global:
-    - MINCONDA_VERSION="latest"
-    - MINCONDA_LINUX="Linux-x86_64"
-    - MINCONDA_OSX="MacOSX-x86_64"
+    - SETUP_XVFB=True
+    - CONDA_DEPENDENCIES='pytest'
+
 matrix:
   include:
-    # Linux
     - python: "2.7"
       env: USE_QT_API=PyQt5
-      os: linux
     - python: "2.7"
       env: USE_QT_API=PyQt4
-      os: linux
     - python: "2.7"
       env: USE_QT_API=PySide
-      os: linux
     - python: "3.4"
       env: USE_QT_API=PyQt4
-      os: linux
     - python: "3.5"
       env: USE_QT_API=PyQt5
-      os: linux
     - python: "3.5"
       env: USE_QT_API=PyQt4
-      os: linux
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-install:
-  # Define the value to download
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      MINCONDA_OS=$MINCONDA_LINUX;
-    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      MINCONDA_OS=$MINCONDA_OSX;
-    fi
-  # You may want to periodically update this, although the conda update
-  # conda line below will keep everything up-to-date. We do this
-  # conditionally because it saves us some downloading if the version is
-  # the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget "http://repo.continuum.io/miniconda/Miniconda-$MINCONDA_VERSION-$MINCONDA_OS.sh" -O miniconda.sh;
-    else
-      wget "http://repo.continuum.io/miniconda/Miniconda3-$MINCONDA_VERSION-$MINCONDA_OS.sh" -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
 
+before_install:
   # Test environments for different Qt bindings
   - if [[ "$USE_QT_API" == "PyQt5" ]]; then
-      conda config --add channels spyder-ide;
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION qt5 pyqt5;
+      export CONDA_DEPENDENCIES='qt5 pyqt5'$CONDA_DEPENDENCIES
+      export CONDA_CHANNELS='spyder-ide'
     elif [[ "$USE_QT_API" == "PyQt4" ]]; then
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION qt pyqt;
+      export CONDA_DEPENDENCIES='qt pyqt'$CONDA_DEPENDENCIES
     elif [[ "$USE_QT_API" == "PySide" ]]; then
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION qt pyside;
+      export CONDA_DEPENDENCIES='qt pyside'$CONDA_DEPENDENCIES
     fi
-  - source activate test-environment
-  - conda install -q pytest
+
+install:
+  - git clone git://github.com/astropy/ci-helpers.git
+  - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
   - python setup.py install
+
 before_script:
   - cd tests
+
 script:
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ env:
   global:
     - SETUP_XVFB=True
     - CONDA_DEPENDENCIES='pytest'
-
-matrix:
-  include:
+  matrix:
     - python: "2.7"
       env: USE_QT_API=PyQt5
     - python: "2.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
 
-# Not a .NET project, we build SunPy in the install step instead
+# Not a .NET project, we build in the install step instead
 build: false
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@ environment:
 
   matrix:
 
-    - PYTHON_VERSION: "2.7"
-      CONDA_CHANNELS: "msarahan"
-      CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
+    # - PYTHON_VERSION: "2.7"
+    #   CONDA_CHANNELS: "msarahan"
+    #   CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
     - PYTHON_VERSION: "2.7"
       CONDA_DEPENDENCIES: "pytest qt pyqt"
     - PYTHON_VERSION: "2.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ environment:
   matrix:
 
     - PYTHON_VERSION: "2.7"
-      CONDA_CHANNELS: "spyder-ide"
+      CONDA_CHANNELS: "msarahan"
       CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
     - PYTHON_VERSION: "2.7"
       CONDA_DEPENDENCIES: "pytest qt pyqt"
     - PYTHON_VERSION: "2.7"
       CONDA_DEPENDENCIES: "pytest qt pyside"
     - PYTHON_VERSION: "3.5"
-      CONDA_CHANNELS: "spyder-ide"
+      CONDA_CHANNELS: "msarahan"
       CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
     - PYTHON_VERSION: "3.5"
       CONDA_DEPENDENCIES: "pytest qt pyqt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ environment:
       CONDA_DEPENDENCIES: "pytest qt pyqt"
     - PYTHON_VERSION: "2.7"
       CONDA_DEPENDENCIES: "pytest qt pyside"
-    - PYTHON_VERSION: "3.5"
-      CONDA_CHANNELS: "msarahan"
-      CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
+    # - PYTHON_VERSION: "3.5"
+    #   CONDA_CHANNELS: "msarahan"
+    #   CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
     - PYTHON_VERSION: "3.5"
       CONDA_DEPENDENCIES: "pytest qt pyqt"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+environment:
+
+  global:
+      PYTHON: "C:\\conda"
+      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+      PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
+                        # of 32 bit and 64 bit builds are needed, move this
+                        # to the matrix section.
+
+  matrix:
+    - PYTHON_VERSION: "2.7"
+      CONDA_DEPENDENCIES='pytest qt5 pyqt5' CONDA_CHANNELS='spyder-ide'
+    - PYTHON_VERSION: "2.7"
+      CONDA_DEPENDENCIES='pytest qt pyqt'
+    - PYTHON_VERSION: "2.7"
+      CONDA_DEPENDENCIES='pytest qt pyside'
+    - PYTHON_VERSION: "3.5"
+      CONDA_DEPENDENCIES='pytest qt5 pyqt5' CONDA_CHANNELS='spyder-ide'
+    - PYTHON_VERSION: "3.5"
+      CONDA_DEPENDENCIES='pytest qt pyqt'
+
+platform:
+    -x64
+
+install:
+    - "git clone git://github.com/astropy/ci-helpers.git"
+    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "activate test"
+
+# Not a .NET project, we build SunPy in the install step instead
+build: false
+
+test_script:
+  - "%CMD_IN_ENV% py.test"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,16 +8,19 @@ environment:
                         # to the matrix section.
 
   matrix:
+
     - PYTHON_VERSION: "2.7"
-      CONDA_DEPENDENCIES='pytest qt5 pyqt5' CONDA_CHANNELS='spyder-ide'
+      CONDA_CHANNELS: "spyder-ide"
+      CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
     - PYTHON_VERSION: "2.7"
-      CONDA_DEPENDENCIES='pytest qt pyqt'
+      CONDA_DEPENDENCIES: "pytest qt pyqt"
     - PYTHON_VERSION: "2.7"
-      CONDA_DEPENDENCIES='pytest qt pyside'
+      CONDA_DEPENDENCIES: "pytest qt pyside"
     - PYTHON_VERSION: "3.5"
-      CONDA_DEPENDENCIES='pytest qt5 pyqt5' CONDA_CHANNELS='spyder-ide'
+      CONDA_CHANNELS: "spyder-ide"
+      CONDA_DEPENDENCIES: "pytest qt5 pyqt5"
     - PYTHON_VERSION: "3.5"
-      CONDA_DEPENDENCIES='pytest qt pyqt'
+      CONDA_DEPENDENCIES: "pytest qt pyqt"
 
 platform:
     -x64

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,5 @@
 import os
 
-from distutils.version import LooseVersion
-
 from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
 
 def assert_pyside():
@@ -34,11 +32,10 @@ def assert_pyqt5():
     assert QtCore.QEvent is PyQt5.QtCore.QEvent
     assert QtGui.QPainter is PyQt5.QtGui.QPainter
     assert QtWidgets.QWidget is PyQt5.QtWidgets.QWidget
-    from PyQt5 import Qt
-    if LooseVersion(Qt.PYQT_VERSION_STR) < LooseVersion('5.6'):
-        assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
-    else:
+    if QtWebEngineWidgets.WEBENGINE:
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebEngineWidgets.QWebEnginePage
+    else:
+        assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
 
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,8 @@
 import os
 
-from distutils import LooseVersion
+from distutils.version import LooseVersion
 
 from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
-from qtpy.QtCore import Qt
-
-QT_LT_56 = LooseVersion(Qt.PYQT_VERSION_STR) < LooseVersion('5.6')
 
 def assert_pyside():
     """
@@ -37,7 +34,8 @@ def assert_pyqt5():
     assert QtCore.QEvent is PyQt5.QtCore.QEvent
     assert QtGui.QPainter is PyQt5.QtGui.QPainter
     assert QtWidgets.QWidget is PyQt5.QtWidgets.QWidget
-    if QT_LT_56:
+    from PyQt5 import Qt
+    if LooseVersion(Qt.PYQT_VERSION_STR) < LooseVersion('5.6'):
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
     else:
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebEngineWidgets.QWebEnginePage

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,11 @@
 import os
 
-from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
+from distutils import LooseVersion
 
+from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
+from qtpy.QtCore import Qt
+
+QT_LT_56 = LooseVersion(Qt.PYQT_VERSION_STR) < LooseVersion('5.6')
 
 def assert_pyside():
     """
@@ -33,7 +37,11 @@ def assert_pyqt5():
     assert QtCore.QEvent is PyQt5.QtCore.QEvent
     assert QtGui.QPainter is PyQt5.QtGui.QPainter
     assert QtWidgets.QWidget is PyQt5.QtWidgets.QWidget
-    assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
+    if QT_LT_56:
+        assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
+    else:
+        assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebEngineWidgets.QWebEnginePage
+
 
 
 def test_qt_api():


### PR DESCRIPTION
Over at the Astropy project, we've developed [ci-helpers](https://github.com/astropy/ci-helpers), which is a set of well tested scripts to help with setting up conda environments for continuous integration. This is not at all astronomy specific and we are interested in getting other projects to adopt it too. This PR shows how you can use it in the Travis configuration, and also adds a configuration file for AppVeyor, in case you would like to turn that on. I've also enabled OSX testing on Travis.

[to see the benefits of using ci-helpers, note that this PR only adds a net 6 lines but that includes adding the appveyor configuration]

If you are interested in going ahead with this, try turning on AppVeyor and I'll force push to this branch again to trigger a build.

Note that https://github.com/spyder-ide/qtpy/pull/28 should be merged first, after which I'll rebase this.