### PR TITLE
Added is_py* helper functions to help determine which Qt bindings are in use

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -127,3 +127,27 @@ if API in PYSIDE_API:
         PYSIDE = True
     except ImportError:
         raise PythonQtError('No Qt bindings could be found')
+
+
+def is_pyside():
+    """
+    Helper function that returns a boolean indicating whether we are using
+    PySide.
+    """
+    return API in PYSIDE_API
+
+
+def is_pyqt4():
+    """
+    Helper function that returns a boolean indicating whether we are using
+    PyQt4.
+    """
+    return API in PYQT4_API
+
+
+def is_pyqt5():
+    """
+    Helper function that returns a boolean indicating whether we are using
+    PyQt5.
+    """
+    return API in PYQT5_API

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,14 @@
 import os
 
-from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
+from qtpy import (QtCore, QtGui, QtWidgets, QtWebEngineWidgets, is_pyside,
+                  is_pyqt4, is_pyqt5)
+
 
 def assert_pyside():
     """
     Make sure that we are using PySide
     """
+    assert is_pyside()
     import PySide
     assert QtCore.QEvent is PySide.QtCore.QEvent
     assert QtGui.QPainter is PySide.QtGui.QPainter
@@ -17,6 +20,7 @@ def assert_pyqt4():
     """
     Make sure that we are using PyQt4
     """
+    assert is_pyqt4()
     import PyQt4
     assert QtCore.QEvent is PyQt4.QtCore.QEvent
     assert QtGui.QPainter is PyQt4.QtGui.QPainter
@@ -28,6 +32,7 @@ def assert_pyqt5():
     """
     Make sure that we are using PyQt5
     """
+    assert is_pyqt5()
     import PyQt5
     assert QtCore.QEvent is PyQt5.QtCore.QEvent
     assert QtGui.QPainter is PyQt5.QtGui.QPainter
@@ -36,7 +41,6 @@ def assert_pyqt5():
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebEngineWidgets.QWebEnginePage
     else:
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
-
 
 
 def test_qt_api():


### PR DESCRIPTION
This is pretty simple, and you could argue maybe they aren't needed - but for me they are quite useful because it's easier to remember ``is_pyside`` rather than figure out what the internal API variables are :) (and using ``is_pyside`` in code looks cleaner). There are some rare cases where even though we're using qtpy, we need to know which binding we are using.