### PR TITLE
Remove QItemSelectionModel from QtWidgets for PyQt4 and PySide

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -63,7 +63,8 @@ elif os.environ[QT_API] in PYQT4_API:
          QPrintPreviewDialog, QPrintPreviewWidget, QPrinter, QPrinterInfo)
 
     # These objects belong to QtCore
-    del (QItemSelection, QItemSelectionRange, QSortFilterProxyModel)
+    del (QItemSelection, QItemSelectionModel, QItemSelectionRange,
+         QSortFilterProxyModel)
 elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4
@@ -103,6 +104,7 @@ elif os.environ[QT_API] in PYSIDE_API:
          QPrintPreviewDialog, QPrintPreviewWidget, QPrinter, QPrinterInfo)
 
     # These objects belong to QtCore
-    del (QItemSelection, QItemSelectionRange, QSortFilterProxyModel)
+    del (QItemSelection, QItemSelectionModel, QItemSelectionRange,
+         QSortFilterProxyModel)
 else:
     raise PythonQtError('No Qt bindings could be found')


### PR DESCRIPTION
- It belongs to QtCore in PyQt5.
- This finishes PR #31.

----

@astrofrog, sorry I missed this one in my review. We follow the philosophy of removing objects belonging to two modules to avoid confusions among our users.

This also makes people to really use the Qt5 layout.