### PR TITLE
Ignore case for QT_API env variable in qtpy submodules

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,20 +10,19 @@
 Provides QtCore classes and functions.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtCore import *
     from PyQt5.QtCore import pyqtSignal as Signal
     from PyQt5.QtCore import pyqtSlot as Slot
     from PyQt5.QtCore import pyqtProperty as Property
     from PyQt5.QtCore import QT_VERSION_STR as __version__
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtCore import *
     from PyQt4.QtCore import QCoreApplication
     from PyQt4.QtCore import Qt
@@ -33,7 +32,7 @@ elif API in PYQT4_API:
     from PyQt4.QtGui import (QItemSelection, QItemSelectionModel,
                              QItemSelectionRange, QSortFilterProxyModel)
     from PyQt4.QtCore import QT_VERSION_STR as __version__
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtCore import *
     from PySide.QtGui import (QItemSelection, QItemSelectionModel,
                               QItemSelectionRange, QSortFilterProxyModel)

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,10 +10,7 @@
 Provides QtCore classes and functions.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,22 +10,20 @@
 Provides QtCore classes and functions.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtCore import *
     from PyQt5.QtCore import pyqtSignal as Signal
     from PyQt5.QtCore import pyqtSlot as Slot
     from PyQt5.QtCore import pyqtProperty as Property
     from PyQt5.QtCore import QT_VERSION_STR as __version__
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtCore import *
     from PyQt4.QtCore import QCoreApplication
     from PyQt4.QtCore import Qt
@@ -35,7 +33,7 @@ elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtGui import (QItemSelection, QItemSelectionModel,
                              QItemSelectionRange, QSortFilterProxyModel)
     from PyQt4.QtCore import QT_VERSION_STR as __version__
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtCore import *
     from PySide.QtGui import (QItemSelection, QItemSelectionModel,
                               QItemSelectionRange, QSortFilterProxyModel)

--- a/qtpy/QtDesigner.py
+++ b/qtpy/QtDesigner.py
@@ -9,17 +9,15 @@
 Provides QtDesigner classes and functions.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtDesigner import *
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtDesigner import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtDesigner.py
+++ b/qtpy/QtDesigner.py
@@ -9,9 +9,7 @@
 Provides QtDesigner classes and functions.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtDesigner.py
+++ b/qtpy/QtDesigner.py
@@ -9,15 +9,14 @@
 Provides QtDesigner classes and functions.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
+from qtpy import PYQT5
+from qtpy import PYQT4
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtDesigner import *
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtDesigner import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -13,16 +13,15 @@ Provides QtGui classes and functions.
     the ``PyQt5.QtGui`` module.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtGui import *
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.Qt import QKeySequence, QTextCursor
     from PyQt4.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
                              QBrush, QClipboard, QCloseEvent, QColor,
@@ -63,7 +62,7 @@ elif API in PYQT4_API:
                              QWindowStateChangeEvent, qAlpha, qBlue,
                              qFuzzyCompare, qGray, qGreen, qIsGray, qRed, qRgb,
                              qRgba, QIntValidator)
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
                               QBrush, QClipboard, QCloseEvent, QColor,
                               QConicalGradient, QContextMenuEvent, QCursor,

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -13,10 +13,7 @@ Provides QtGui classes and functions.
     the ``PyQt5.QtGui`` module.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -13,18 +13,16 @@ Provides QtGui classes and functions.
     the ``PyQt5.QtGui`` module.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtGui import *
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.Qt import QKeySequence, QTextCursor
     from PyQt4.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
                              QBrush, QClipboard, QCloseEvent, QColor,
@@ -65,7 +63,7 @@ elif os.environ[QT_API] in PYQT4_API:
                              QWindowStateChangeEvent, qAlpha, qBlue,
                              qFuzzyCompare, qGray, qGreen, qIsGray, qRed, qRgb,
                              qRgba, QIntValidator)
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
                               QBrush, QClipboard, QCloseEvent, QColor,
                               QConicalGradient, QContextMenuEvent, QCursor,

--- a/qtpy/QtNetwork.py
+++ b/qtpy/QtNetwork.py
@@ -10,10 +10,7 @@
 Provides QtNetwork classes and functions.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtNetwork.py
+++ b/qtpy/QtNetwork.py
@@ -10,18 +10,17 @@
 Provides QtNetwork classes and functions.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtNetwork import *
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtNetwork import *
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtNetwork import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtNetwork.py
+++ b/qtpy/QtNetwork.py
@@ -10,20 +10,18 @@
 Provides QtNetwork classes and functions.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtNetwork import *
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtNetwork import *
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtNetwork import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtPrintSupport.py
+++ b/qtpy/QtPrintSupport.py
@@ -9,20 +9,19 @@
 Provides QtPrintSupport classes and functions.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtPrintSupport import *
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtGui import (QAbstractPrintDialog, QPageSetupDialog,
                              QPrintDialog, QPrintEngine, QPrintPreviewDialog,
                              QPrintPreviewWidget, QPrinter, QPrinterInfo)
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtGui import (QAbstractPrintDialog, QPageSetupDialog,
                               QPrintDialog, QPrintEngine, QPrintPreviewDialog,
                               QPrintPreviewWidget, QPrinter, QPrinterInfo)

--- a/qtpy/QtPrintSupport.py
+++ b/qtpy/QtPrintSupport.py
@@ -9,10 +9,7 @@
 Provides QtPrintSupport classes and functions.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtPrintSupport.py
+++ b/qtpy/QtPrintSupport.py
@@ -9,22 +9,20 @@
 Provides QtPrintSupport classes and functions.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtPrintSupport import *
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtGui import (QAbstractPrintDialog, QPageSetupDialog,
                              QPrintDialog, QPrintEngine, QPrintPreviewDialog,
                              QPrintPreviewWidget, QPrinter, QPrinterInfo)
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtGui import (QAbstractPrintDialog, QPageSetupDialog,
                               QPrintDialog, QPrintEngine, QPrintPreviewDialog,
                               QPrintPreviewWidget, QPrinter, QPrinterInfo)

--- a/qtpy/QtSvg.py
+++ b/qtpy/QtSvg.py
@@ -8,10 +8,7 @@
 Provides QtSvg classes and functions.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtSvg.py
+++ b/qtpy/QtSvg.py
@@ -8,18 +8,17 @@
 Provides QtSvg classes and functions.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtSvg import *
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtSvg import *
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtSvg import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtSvg.py
+++ b/qtpy/QtSvg.py
@@ -8,20 +8,18 @@
 Provides QtSvg classes and functions.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtSvg import *
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtSvg import *
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtSvg import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtTest.py
+++ b/qtpy/QtTest.py
@@ -12,25 +12,23 @@ Provides QtTest and functions
     running with PySide.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     from PyQt5.QtTest import QTest
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtTest import QTest as OldQTest
 
     class QTest(OldQTest):
         @staticmethod
         def qWaitForWindowActive(QWidget):
             OldQTest.qWaitForWindowShown(QWidget)
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     raise ImportError('QtTest support is incomplete for PySide')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtTest.py
+++ b/qtpy/QtTest.py
@@ -12,10 +12,7 @@ Provides QtTest and functions
     running with PySide.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtTest.py
+++ b/qtpy/QtTest.py
@@ -12,23 +12,22 @@ Provides QtTest and functions
     running with PySide.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtTest import QTest
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtTest import QTest as OldQTest
 
     class QTest(OldQTest):
         @staticmethod
         def qWaitForWindowActive(QWidget):
             OldQTest.qWaitForWindowShown(QWidget)
-elif API in PYSIDE_API:
+elif PYSIDE:
     raise ImportError('QtTest support is incomplete for PySide')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -10,10 +10,7 @@
 Provides QtWebEngineWidgets classes and functions.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 # To test if we are using WebEngine or WebKit

--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -10,10 +10,9 @@
 Provides QtWebEngineWidgets classes and functions.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 
 
@@ -21,7 +20,7 @@ from qtpy import PythonQtError
 WEBENGINE = True
 
 
-if API in PYQT5_API:
+if PYQT5:
     try:
         from PyQt5.QtWebEngineWidgets import QWebEnginePage
         from PyQt5.QtWebEngineWidgets import QWebEngineView
@@ -31,12 +30,12 @@ if API in PYQT5_API:
         from PyQt5.QtWebKitWidgets import QWebView as QWebEngineView
         from PyQt5.QtWebKit import QWebSettings as QWebEngineSettings
         WEBENGINE = False
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtWebKit import QWebPage as QWebEnginePage
     from PyQt4.QtWebKit import QWebView as QWebEngineView
     from PyQt4.QtWebKit import QWebSettings as QWebEngineSettings
     WEBENGINE = False
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtWebKit import QWebPage as QWebEnginePage
     from PySide.QtWebKit import QWebView as QWebEngineView
     from PySide.QtWebKit import QWebSettings as QWebEngineSettings

--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -10,9 +10,7 @@
 Provides QtWebEngineWidgets classes and functions.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
@@ -23,7 +21,7 @@ from qtpy import PythonQtError
 WEBENGINE = True
 
 
-if os.environ[QT_API] in PYQT5_API:
+if API in PYQT5_API:
     try:
         from PyQt5.QtWebEngineWidgets import QWebEnginePage
         from PyQt5.QtWebEngineWidgets import QWebEngineView
@@ -33,12 +31,12 @@ if os.environ[QT_API] in PYQT5_API:
         from PyQt5.QtWebKitWidgets import QWebView as QWebEngineView
         from PyQt5.QtWebKit import QWebSettings as QWebEngineSettings
         WEBENGINE = False
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtWebKit import QWebPage as QWebEnginePage
     from PyQt4.QtWebKit import QWebView as QWebEngineView
     from PyQt4.QtWebKit import QWebSettings as QWebEngineSettings
     WEBENGINE = False
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtWebKit import QWebPage as QWebEnginePage
     from PySide.QtWebKit import QWebView as QWebEngineView
     from PySide.QtWebKit import QWebSettings as QWebEngineSettings

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -13,10 +13,7 @@ Provides widget classes and functions.
     were the ``PyQt5.QtWidgets`` module.
 """
 
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
-from qtpy import PythonQtError
+from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
 from qtpy._patch.qcombobox import patch_qcombobox
 
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -13,17 +13,16 @@ Provides widget classes and functions.
     were the ``PyQt5.QtWidgets`` module.
 """
 
-from qtpy import API
-from qtpy import PYQT5_API
-from qtpy import PYQT4_API
-from qtpy import PYSIDE_API
+from qtpy import PYQT5
+from qtpy import PYQT4
+from qtpy import PYSIDE
 from qtpy import PythonQtError
 from qtpy._patch.qcombobox import patch_qcombobox
 
 
-if API in PYQT5_API:
+if PYQT5:
     from PyQt5.QtWidgets import *
-elif API in PYQT4_API:
+elif PYQT4:
     from PyQt4.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4
 
@@ -68,7 +67,7 @@ elif API in PYQT4_API:
     # Patch QComboBox to allow Python objects to be passed to userData
     patch_qcombobox(QComboBox)
 
-elif API in PYSIDE_API:
+elif PYSIDE:
     from PySide.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -13,18 +13,17 @@ Provides widget classes and functions.
     were the ``PyQt5.QtWidgets`` module.
 """
 
-import os
-
-from qtpy import QT_API
+from qtpy import API
 from qtpy import PYQT5_API
 from qtpy import PYQT4_API
 from qtpy import PYSIDE_API
 from qtpy import PythonQtError
 from qtpy._patch.qcombobox import patch_qcombobox
 
-if os.environ[QT_API] in PYQT5_API:
+
+if API in PYQT5_API:
     from PyQt5.QtWidgets import *
-elif os.environ[QT_API] in PYQT4_API:
+elif API in PYQT4_API:
     from PyQt4.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4
 
@@ -69,7 +68,7 @@ elif os.environ[QT_API] in PYQT4_API:
     # Patch QComboBox to allow Python objects to be passed to userData
     patch_qcombobox(QComboBox)
 
-elif os.environ[QT_API] in PYSIDE_API:
+elif API in PYSIDE_API:
     from PySide.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4
 

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -119,7 +119,7 @@ if API in PYSIDE_API:
 
 API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyqt4': 'PyQt4',
             'pyside': 'PySide'}[API]
-if API in PYQT4_API:
+if PYQT4:
         import sip
         try:
             API_NAME += (" (API v{0})".format(sip.getapi('QString')))

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -64,12 +64,8 @@ PYQT4_API = [
 #: names of the expected PySide api
 PYSIDE_API = ['pyside']
 
-os.environ.setdefault(QT_API, 'pyqt5')
-assert os.environ[QT_API] in (PYQT5_API + PYQT4_API + PYSIDE_API)
-
-API = os.environ[QT_API]
-API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyqt4': 'PyQt4',
-            'pyside': 'PySide'}[API]
+API = os.environ.get(QT_API, 'pyqt5').lower()
+assert API in (PYQT5_API + PYQT4_API + PYSIDE_API)
 
 is_old_pyqt = is_pyqt46 = False
 PYQT5 = True
@@ -86,8 +82,7 @@ if API in PYQT5_API:
         from PyQt5.QtCore import PYQT_VERSION_STR as __version__
         from PyQt5 import uic                                     # analysis:ignore
     except ImportError:
-        API = os.environ['QT_API'] = 'pyqt'
-        API_NAME = 'PyQt4'
+        API = 'pyqt'
 
 if API in PYQT4_API:
     try:
@@ -109,16 +104,10 @@ if API in PYQT4_API:
         PYQT5 = False
         PYQT4 = True
     except ImportError:
-        API = os.environ['QT_API'] = 'pyside'
-        API_NAME = 'PySide'
+        API = 'pyside'
     else:
         is_old_pyqt = __version__.startswith(('4.4', '4.5', '4.6', '4.7'))
         is_pyqt46 = __version__.startswith('4.6')
-        import sip
-        try:
-            API_NAME += (" (API v{0})".format(sip.getapi('QString')))
-        except AttributeError:
-            pass
 
 if API in PYSIDE_API:
     try:
@@ -127,3 +116,12 @@ if API in PYSIDE_API:
         PYSIDE = True
     except ImportError:
         raise PythonQtError('No Qt bindings could be found')
+
+API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyqt4': 'PyQt4',
+            'pyside': 'PySide'}[API]
+if API in PYQT4_API:
+        import sip
+        try:
+            API_NAME += (" (API v{0})".format(sip.getapi('QString')))
+        except AttributeError:
+            pass

--- a/qtpy/compat.py
+++ b/qtpy/compat.py
@@ -8,10 +8,10 @@ Compatibility functions
 """
 
 from __future__ import print_function
-import os
 import sys
 import collections
 
+from qtpy import API, PYQT4_API
 from qtpy.QtWidgets import QFileDialog
 from qtpy.py3compat import is_text_string, to_text_string, TEXT_TYPES
 
@@ -20,7 +20,7 @@ from qtpy.py3compat import is_text_string, to_text_string, TEXT_TYPES
 # QVariant conversion utilities
 # =============================================================================
 PYQT_API_1 = False
-if os.environ['QT_API'] == 'pyqt':
+if API in PYQT4_API:
     import sip
     try:
         PYQT_API_1 = sip.getapi('QVariant') == 1  # PyQt API #1

--- a/qtpy/compat.py
+++ b/qtpy/compat.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import sys
 import collections
 
-from qtpy import API, PYQT4_API
+from qtpy import PYQT4
 from qtpy.QtWidgets import QFileDialog
 from qtpy.py3compat import is_text_string, to_text_string, TEXT_TYPES
 
@@ -20,7 +20,7 @@ from qtpy.py3compat import is_text_string, to_text_string, TEXT_TYPES
 # QVariant conversion utilities
 # =============================================================================
 PYQT_API_1 = False
-if API in PYQT4_API:
+if PYQT4:
     import sip
     try:
         PYQT_API_1 = sip.getapi('QVariant') == 1  # PyQt API #1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import os
 
 from qtpy import QtCore, QtGui, QtWidgets, QtWebEngineWidgets
 
+
 def assert_pyside():
     """
     Make sure that we are using PySide
@@ -38,13 +39,12 @@ def assert_pyqt5():
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
 
 
-
 def test_qt_api():
     """
     If QT_API is specified, we check that the correct Qt wrapper was used
     """
 
-    QT_API = os.environ.get('QT_API')
+    QT_API = os.environ.get('QT_API', '').lower()
 
     if QT_API == 'pyside':
         assert_pyside()


### PR DESCRIPTION
This is easier on the users, and the tests are currently failing because of this problem.

I got rid of the `os.environ[QT_API]` lookups, because it makes qtpy rely too much on an external global state, while the environent is already pared in `__init__.py`. This makes the import thread safe, for example.

With this I think that https://github.com/spyder-ide/spyder/pull/3210 won't fail anymore.