### PR TITLE
Automatically load custom widget classes when using PySide

### DIFF
--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -171,10 +171,10 @@ elif PYSIDE:
         # Get the customwidgets section
         custom_widgets = ui.find('customwidgets')
 
-        custom_widget_classes = dict()
-
         if custom_widgets is None:
-            return custom_widget_classes
+            return {}
+
+        custom_widget_classes = {}
 
         for custom_widget in custom_widgets.getchildren():
 

--- a/tests/test_uic.py
+++ b/tests/test_uic.py
@@ -2,9 +2,7 @@ import os
 import sys
 import contextlib
 
-import pytest
-
-from qtpy import QtWidgets, PYSIDE
+from qtpy import QtWidgets
 from qtpy.QtWidgets import QComboBox
 from qtpy.uic import loadUi
 
@@ -53,29 +51,6 @@ def test_load_ui():
     assert isinstance(ui.comboBox, QComboBox)
 
 
-def test_load_ui_custom(tmpdir):
-    """
-    Test that we can load a .ui file with custom widgets
-    """
-
-    app = get_qapp()
-
-    with enabled_qcombobox_subclass(tmpdir):
-        from qcombobox_subclass import _QComboBoxSubclass
-        if PYSIDE:
-            customWidgets = {'_QComboBoxSubclass': _QComboBoxSubclass}
-            ui = loadUi(os.path.join(os.path.dirname(__file__), 'test_custom.ui'),
-                        customWidgets=customWidgets)
-        else:
-            ui = loadUi(os.path.join(os.path.dirname(__file__), 'test_custom.ui'))
-
-    assert isinstance(ui.pushButton, QtWidgets.QPushButton)
-    assert isinstance(ui.comboBox, _QComboBoxSubclass)
-
-
-@pytest.mark.xfail(PYSIDE, reason='The PySide loadUi wrapper does not yet '
-                                  'support determining custom widgets '
-                                  'automatically')
 def test_load_ui_custom_auto(tmpdir):
     """
     Test that we can load a .ui file with custom widgets without having to


### PR DESCRIPTION
This is a follow-up to https://github.com/spyder-ide/qtpy/pull/27 (and will be rebased once that is merged) which includes auto-loading of custom widget classes by parsing the ui files. This then makes the behavior of loadUi consistent with that in PyQt4/5.

This is still a work in progress - I need to test this extensively with glue to make sure that it always works. I'm also not entirely happy with the sys.path hack, and want to try and find a better solution. As such, this is not ready for a proper review, but any preliminary feedback/suggestions would be useful (will be easier to see the changes here once #27 is merged)