### PR TITLE
Fix remaining segmentation fault that occurs with the patched QComboBox in PySide

### DIFF
--- a/qtpy/_patch/qcombobox.py
+++ b/qtpy/_patch/qcombobox.py
@@ -45,13 +45,13 @@ def patch_qcombobox(QComboBox):
     from qtpy.QtGui import QIcon
     from qtpy.QtCore import Qt, QObject
 
-    class userDataWrapper(QObject):
+    class userDataWrapper():
         """
-        This class is used to wrap any userData object inside a QObject which
-        is then supported by all Python Qt wrappers.
+        This class is used to wrap any userData object. If we don't do this,
+        then certain types of objects can cause segmentation faults or issues
+        depending on whether/how __getitem__ is defined.
         """
-        def __init__(self, data, parent=None):
-            super(userDataWrapper, self).__init__(parent)
+        def __init__(self, data):
             self.data = data
 
     _addItem = QComboBox.addItem
@@ -61,8 +61,7 @@ def patch_qcombobox(QComboBox):
                               and len(args) == 2):
             args, kwargs['userData'] = args[:-1], args[-1]
         if 'userData' in kwargs:
-            kwargs['userData'] = userDataWrapper(kwargs['userData'],
-                                                 parent=self)
+            kwargs['userData'] = userDataWrapper(kwargs['userData'])
         _addItem(self, *args, **kwargs)
 
     _insertItem = QComboBox.insertItem
@@ -72,14 +71,13 @@ def patch_qcombobox(QComboBox):
                               and len(args) == 3):
             args, kwargs['userData'] = args[:-1], args[-1]
         if 'userData' in kwargs:
-            kwargs['userData'] = userDataWrapper(kwargs['userData'],
-                                                 parent=self)
+            kwargs['userData'] = userDataWrapper(kwargs['userData'])
         _insertItem(self, *args, **kwargs)
 
     _setItemData = QComboBox.setItemData
 
     def setItemData(self, index, value, role=Qt.UserRole):
-        value = userDataWrapper(value, parent=self)
+        value = userDataWrapper(value)
         _setItemData(self, index, value, role=role)
 
     _itemData = QComboBox.itemData

--- a/tests/test_patch_qcombobox.py
+++ b/tests/test_patch_qcombobox.py
@@ -9,6 +9,15 @@ def get_qapp(icon_path=None):
     return qapp
 
 
+class Data(object):
+    """
+    Test class to store in userData. The __getitem__ is needed in order to
+    reproduce the segmentation fault.
+    """
+    def __getitem__(self, item):
+        raise ValueError("Failing")
+
+
 def test_patched_qcombobox():
     """
     In PySide, using Python objects as userData in QComboBox causes
@@ -20,14 +29,6 @@ def test_patched_qcombobox():
     """
 
     app = get_qapp()
-
-    class Data(object):
-        """
-        Test class to store in userData. The __getitem__ is needed in order to
-        reproduce the segmentation fault.
-        """
-        def __getitem__(self, item):
-            raise ValueError("Failing")
 
     data1 = Data()
     data2 = Data()
@@ -73,3 +74,27 @@ def test_patched_qcombobox():
     assert widget.itemText(4) == 'd'
     assert widget.itemText(5) == 'g'
     assert widget.itemText(6) == 'f'
+
+
+def test_model_item():
+    """
+    This is a regression test for an issue that caused the call to item(0)
+    below to trigger segmentation faults in PySide. The issue is
+    non-deterministic when running the call once, so we include a loop to make
+    sure that we trigger the fault.
+    """
+
+    app = get_qapp()
+
+    combo = QtWidgets.QComboBox()
+
+    label_data = [('a', None)]
+
+    for iter in range(10000):
+
+        combo.clear()
+        for i, (label, data) in enumerate(label_data):
+            combo.addItem(label, userData=data)
+
+        model = combo.model()
+        model.item(0)

--- a/tests/test_patch_qcombobox.py
+++ b/tests/test_patch_qcombobox.py
@@ -83,18 +83,12 @@ def test_model_item():
     non-deterministic when running the call once, so we include a loop to make
     sure that we trigger the fault.
     """
-
     app = get_qapp()
-
     combo = QtWidgets.QComboBox()
-
     label_data = [('a', None)]
-
     for iter in range(10000):
-
         combo.clear()
         for i, (label, data) in enumerate(label_data):
             combo.addItem(label, userData=data)
-
         model = combo.model()
         model.item(0)


### PR DESCRIPTION
For now, I'm adding a regression test to make sure it fails on Travis/AppVeyor. This includes #37 and should be rebased once #37 is merged.