### PR TITLE
QtTest for PySide

### DIFF
--- a/qtpy/QtTest.py
+++ b/qtpy/QtTest.py
@@ -8,8 +8,6 @@
 
 """
 Provides QtTest and functions
-.. warning:: PySide is not supported here, that's why there is not unit tests
-    running with PySide.
 """
 
 from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
@@ -25,6 +23,6 @@ elif PYQT4:
         def qWaitForWindowActive(QWidget):
             OldQTest.qWaitForWindowShown(QWidget)
 elif PYSIDE:
-    raise ImportError('QtTest support is incomplete for PySide')
+    from PySide.QtTest import QTest
 else:
     raise PythonQtError('No Qt bindings could be found')


### PR DESCRIPTION
In QtTest.py, it says:

```python
"""
Provides QtTest and functions
.. warning:: PySide is not supported here, that's why there is not unit tests
    running with PySide.
"""
```

However, if I replace the exception that is currently raised for PySide with:

```python
    from PySide.QtTest import QTest
```

it works fine. Is there any reason not to do this?