### PR TITLE
qtpy.__version__ should be QtPy version, not Qt version

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -52,6 +52,9 @@ packages::
 
 import os
 
+# Version of QtPy
+__version__ = "1.1.dev0"
+
 #: Qt API environment variable name
 QT_API = 'QT_API'
 #: names of the expected PyQt5 api
@@ -79,7 +82,8 @@ class PythonQtError(Exception):
 
 if API in PYQT5_API:
     try:
-        from PyQt5.QtCore import PYQT_VERSION_STR as __version__
+        from PyQt5.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
+        from PyQt5.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
     except ImportError:
         API = 'pyqt'
 
@@ -97,8 +101,8 @@ if API in PYQT4_API:
         except AttributeError:
             # PyQt < v4.6
             pass
-
-        from PyQt4.QtCore import PYQT_VERSION_STR as __version__  # analysis:ignore
+        from PyQt4.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
+        from PyQt4.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
         PYQT5 = False
         PYQT4 = True
     except ImportError:
@@ -109,7 +113,8 @@ if API in PYQT4_API:
 
 if API in PYSIDE_API:
     try:
-        from PySide import __version__                            # analysis:ignore
+        from PySide import __version__ as PYSIDE_VERSION  # analysis:ignore
+        from PySide.QtCore import __version__ as QT_VERSION  # analysis:ignore
         PYQT5 = False
         PYSIDE = True
     except ImportError:

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -84,6 +84,7 @@ if API in PYQT5_API:
     try:
         from PyQt5.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
         from PyQt5.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
+        PYSIDE_VERSION = None
     except ImportError:
         API = 'pyqt'
 
@@ -103,6 +104,7 @@ if API in PYQT4_API:
             pass
         from PyQt4.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
         from PyQt4.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
+        PYSIDE_VERSION = None
         PYQT5 = False
         PYQT4 = True
     except ImportError:
@@ -115,6 +117,7 @@ if API in PYSIDE_API:
     try:
         from PySide import __version__ as PYSIDE_VERSION  # analysis:ignore
         from PySide.QtCore import __version__ as QT_VERSION  # analysis:ignore
+        PYQT_VERSION = None
         PYQT5 = False
         PYSIDE = True
     except ImportError:

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -53,7 +53,7 @@ packages::
 import os
 
 # Version of QtPy
-__version__ = "1.1.dev0"
+from qtpy._version import __version__
 
 #: Qt API environment variable name
 QT_API = 'QT_API'


### PR DESCRIPTION
I think that ``__version__`` should be set to the actual QtPy version, otherwise packages won't be able to easily check for example that QtPy is recent enough to include certain patches. I think we could then make the Qt and other versions available via e.g.

```
qtpy.QT_VERSION
qtpy.PYSIDE_VERSION
qtpy.PYQT4_VERSION
qtpy.PYQT5_VERSION
```

I'd be happy to include a quick PR to include in QtPy 1.1 if others agree?

Of course, we could have ``qtpy.QTPY_VERSION`` be the QtPy version, but I think it would be counter-intuitive for ``__version__`` to not be that.