### PR TITLE
Remove PyQt variant symbols from QtCore

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -24,6 +24,8 @@ if PYQT5:
     del pyqtSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 elif PYQT4:
     from PyQt4.QtCore import *
+    # Those are things we inherited from Spyder that fix crazy crashes under
+    # some specific situations. (See #34)
     from PyQt4.QtCore import QCoreApplication
     from PyQt4.QtCore import Qt
     from PyQt4.QtCore import pyqtSignal as Signal

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -19,6 +19,9 @@ if PYQT5:
     from PyQt5.QtCore import pyqtSlot as Slot
     from PyQt5.QtCore import pyqtProperty as Property
     from PyQt5.QtCore import QT_VERSION_STR as __version__
+
+    # Those are imported from `import *`
+    del pyqtSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 elif PYQT4:
     from PyQt4.QtCore import *
     from PyQt4.QtCore import QCoreApplication
@@ -29,6 +32,9 @@ elif PYQT4:
     from PyQt4.QtGui import (QItemSelection, QItemSelectionModel,
                              QItemSelectionRange, QSortFilterProxyModel)
     from PyQt4.QtCore import QT_VERSION_STR as __version__
+
+    # Those are imported from `import *`
+    del pyqtSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 elif PYSIDE:
     from PySide.QtCore import *
     from PySide.QtGui import (QItemSelection, QItemSelectionModel,


### PR DESCRIPTION
Fixes #36.
Fixes #35.

I still think that the duplicate imports are very weird and not needed, But it doesn't hurt too much to leave them.