### PR TITLE
PR: Add explicit imports to QtSvg module

### DIFF
--- a/qtpy/QtSvg.py
+++ b/qtpy/QtSvg.py
@@ -1,21 +1,23 @@
 # -*- coding: utf-8 -*-
-#
+# -----------------------------------------------------------------------------
 # Copyright © 2009- The Spyder Development Team
+#
 # Licensed under the terms of the MIT License
 # (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Provides QtSvg classes and functions."""
 
-"""
-Provides QtSvg classes and functions.
-"""
-
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
-
+# Local imports
+from qtpy import PYQT4, PYQT5, PYSIDE, PythonQtError
 
 if PYQT5:
-    from PyQt5.QtSvg import *
+    from PyQt5.QtSvg import (QGraphicsSvgItem, QSvgGenerator, QSvgRenderer,
+                             QSvgWidget)
 elif PYQT4:
-    from PyQt4.QtSvg import *
+    from PyQt4.QtSvg import (QGraphicsSvgItem, QSvgGenerator, QSvgRenderer,
+                             QSvgWidget)
 elif PYSIDE:
-    from PySide.QtSvg import *
+    from PySide.QtSvg import (QGraphicsSvgItem, QSvgGenerator, QSvgRenderer,
+                              QSvgWidget)
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtSvg.py
+++ b/qtpy/QtSvg.py
@@ -21,3 +21,5 @@ elif PYSIDE:
                               QSvgWidget)
 else:
     raise PythonQtError('No Qt bindings could be found')
+
+del PYQT4, PYQT5, PYSIDE


### PR DESCRIPTION
@ccordoba12, @Nodd should we delete `PYQT4, PYQT5, PYSIDE, PythonQtError` from the module at the end?

`del PYQT4, PYQT5, PYSIDE, PythonQtError` ?