### PR TITLE
Remove reference to how qtpy is pronounced in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Copyright © 2009- The Spyder Development Team.
 
 ## Description
 
-**QtPy** (pronounced *'cutie pie'*) is a small abstraction layer that lets you
+**QtPy** is a small abstraction layer that lets you
 write applications using a single API call to either PyQt or PySide.
 
 It provides support for PyQt5, PyQt4 and PySide using the PyQt5 layout (where


### PR DESCRIPTION
you've got an amazing project name here and it's self-explanatory, don't explain the joke

http://tvtropes.org/pmwiki/pmwiki.php/Main/DontExplainTheJoke