### PR TITLE
PR: Use relative imports so its vendored more easily

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,7 +10,7 @@
 Provides QtCore classes and functions.
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtDesigner.py
+++ b/qtpy/QtDesigner.py
@@ -9,7 +9,7 @@
 Provides QtDesigner classes and functions.
 """
 
-from qtpy import PYQT5, PYQT4, PythonQtError
+from . import PYQT5, PYQT4, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -13,7 +13,7 @@ Provides QtGui classes and functions.
     the ``PyQt5.QtGui`` module.
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtMultimedia.py
+++ b/qtpy/QtMultimedia.py
@@ -1,6 +1,6 @@
-from qtpy import PYQT5
-from qtpy import PYQT4
-from qtpy import PYSIDE
+from . import PYQT5
+from . import PYQT4
+from . import PYSIDE
 
 
 if PYQT5:

--- a/qtpy/QtNetwork.py
+++ b/qtpy/QtNetwork.py
@@ -10,7 +10,7 @@
 Provides QtNetwork classes and functions.
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtPrintSupport.py
+++ b/qtpy/QtPrintSupport.py
@@ -9,7 +9,7 @@
 Provides QtPrintSupport classes and functions.
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtSvg.py
+++ b/qtpy/QtSvg.py
@@ -8,7 +8,7 @@
 """Provides QtSvg classes and functions."""
 
 # Local imports
-from qtpy import PYQT4, PYQT5, PYSIDE, PythonQtError
+from . import PYQT4, PYQT5, PYSIDE, PythonQtError
 
 if PYQT5:
     from PyQt5.QtSvg import (QGraphicsSvgItem, QSvgGenerator, QSvgRenderer,

--- a/qtpy/QtTest.py
+++ b/qtpy/QtTest.py
@@ -10,7 +10,7 @@
 Provides QtTest and functions
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 if PYQT5:

--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -10,7 +10,7 @@
 Provides QtWebEngineWidgets classes and functions.
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 
 
 # To test if we are using WebEngine or WebKit

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -13,9 +13,9 @@ Provides widget classes and functions.
     were the ``PyQt5.QtWidgets`` module.
 """
 
-from qtpy import PYQT5, PYQT4, PYSIDE, PythonQtError
-from qtpy._patch.qcombobox import patch_qcombobox
-from qtpy._patch.qheaderview import introduce_renamed_methods_qheaderview
+from . import PYQT5, PYQT4, PYSIDE, PythonQtError
+from ._patch.qcombobox import patch_qcombobox
+from ._patch.qheaderview import introduce_renamed_methods_qheaderview
 
 
 if PYQT5:

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -53,7 +53,7 @@ packages::
 import os
 
 # Version of QtPy
-from qtpy._version import __version__
+from ._version import __version__
 
 #: Qt API environment variable name
 QT_API = 'QT_API'

--- a/qtpy/_patch/qcombobox.py
+++ b/qtpy/_patch/qcombobox.py
@@ -42,8 +42,8 @@ def patch_qcombobox(QComboBox):
     using PyQt4 and PySide to avoid issues.
     """
 
-    from qtpy.QtGui import QIcon
-    from qtpy.QtCore import Qt, QObject
+    from .QtGui import QIcon
+    from .QtCore import Qt, QObject
 
     class userDataWrapper():
         """

--- a/qtpy/_patch/qcombobox.py
+++ b/qtpy/_patch/qcombobox.py
@@ -42,8 +42,8 @@ def patch_qcombobox(QComboBox):
     using PyQt4 and PySide to avoid issues.
     """
 
-    from .QtGui import QIcon
-    from .QtCore import Qt, QObject
+    from ..QtGui import QIcon
+    from ..QtCore import Qt, QObject
 
     class userDataWrapper():
         """

--- a/qtpy/compat.py
+++ b/qtpy/compat.py
@@ -11,9 +11,9 @@ from __future__ import print_function
 import sys
 import collections
 
-from qtpy import PYQT4
-from qtpy.QtWidgets import QFileDialog
-from qtpy.py3compat import is_text_string, to_text_string, TEXT_TYPES
+from . import PYQT4
+from .QtWidgets import QFileDialog
+from .py3compat import is_text_string, to_text_string, TEXT_TYPES
 
 
 # =============================================================================
@@ -105,7 +105,7 @@ def _qfiledialog_wrapper(attr, parent=None, caption='', basedir='',
         options = QFileDialog.Options(0)
     try:
         # PyQt <v4.6 (API #1)
-        from qtpy.QtCore import QString
+        from .QtCore import QString
     except ImportError:
         # PySide or PyQt >=v4.6
         QString = None  # analysis:ignore

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -1,7 +1,7 @@
 import os
 
-from qtpy import PYSIDE, PYQT4, PYQT5
-from qtpy.QtWidgets import QComboBox
+from . import PYSIDE, PYQT4, PYQT5
+from .QtWidgets import QComboBox
 
 __all__ = ['loadUi']
 


### PR DESCRIPTION
I only need QtCore, QtGui, QtWidgets, so it would be nice if I can vendor-in part of the qtpy project. Having relative imports makes this much easier.