### PR TITLE
PR: Include test suite in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include AUTHORS.md
 include CHANGELOG.md
 include LICENSE.txt
 include README.md
+recursive-include qtpy/tests *


### PR DESCRIPTION
Debian, and other Linux distributions, recommends to source upstream Python code from PyPI. However, current releases of `QtPy` are missing the test suite. The latter is desirable for both the package build and CI process in Debian.

This PR includes the test suite to the output of `sdist`. Following the merge of this PR, please consider submitting a new `1.2.0.1` or `1.2.1` release with the included test suite.

Cheers,
Ghis