### PR TITLE
PR: Add support for PyQt 4.6

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -19,6 +19,17 @@ from . import PYQT5, PYQT4, PYSIDE, PythonQtError
 if PYQT5:
     from PyQt5.QtGui import *
 elif PYQT4:
+    try:
+        # Older versions of PyQt4 do not provide these
+        from PyQt4.QtGui import (QGlyphRun, QMatrix2x2, QMatrix2x3,
+                                 QMatrix2x4, QMatrix3x2, QMatrix3x3,
+                                 QMatrix3x4, QMatrix4x2, QMatrix4x3,
+                                 QMatrix4x4, QTouchEvent, QQuaternion,
+                                 QRadialGradient, QRawFont, QStaticText,
+                                 QVector2D, QVector3D, QVector4D,
+                                 qFuzzyCompare)
+    except ImportError:
+        pass
     from PyQt4.Qt import QKeySequence, QTextCursor
     from PyQt4.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
                              QBrush, QClipboard, QCloseEvent, QColor,
@@ -27,22 +38,19 @@ elif PYQT4:
                              QDragEnterEvent, QDragLeaveEvent, QDragMoveEvent,
                              QDropEvent, QFileOpenEvent, QFocusEvent, QFont,
                              QFontDatabase, QFontInfo, QFontMetrics,
-                             QFontMetricsF, QGlyphRun, QGradient, QHelpEvent,
+                             QFontMetricsF, QGradient, QHelpEvent,
                              QHideEvent, QHoverEvent, QIcon, QIconDragEvent,
                              QIconEngine, QImage, QImageIOHandler, QImageReader,
                              QImageWriter, QInputEvent, QInputMethodEvent,
                              QKeyEvent, QLinearGradient,
-                             QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2,
-                             QMatrix3x3, QMatrix3x4, QMatrix4x2, QMatrix4x3,
-                             QMatrix4x4, QMouseEvent, QMoveEvent, QMovie,
+                             QMouseEvent, QMoveEvent, QMovie,
                              QPaintDevice, QPaintEngine, QPaintEngineState,
                              QPaintEvent, QPainter, QPainterPath,
                              QPainterPathStroker, QPalette, QPen, QPicture,
                              QPictureIO, QPixmap, QPixmapCache, QPolygon,
-                             QPolygonF, QQuaternion, QRadialGradient, QRawFont,
-                             QRegExpValidator, QRegion, QResizeEvent,
+                             QPolygonF, QRegExpValidator, QRegion, QResizeEvent,
                              QSessionManager, QShortcutEvent, QShowEvent,
-                             QStandardItem, QStandardItemModel, QStaticText,
+                             QStandardItem, QStandardItemModel,
                              QStatusTipEvent, QSyntaxHighlighter, QTabletEvent,
                              QTextBlock, QTextBlockFormat, QTextBlockGroup,
                              QTextBlockUserData, QTextCharFormat,
@@ -53,11 +61,10 @@ elif PYQT4:
                              QTextLength, QTextLine, QTextList, QTextListFormat,
                              QTextObject, QTextObjectInterface, QTextOption,
                              QTextTable, QTextTableCell, QTextTableCellFormat,
-                             QTextTableFormat, QTouchEvent, QTransform,
-                             QValidator, QVector2D, QVector3D, QVector4D,
-                             QWhatsThisClickedEvent, QWheelEvent,
+                             QTextTableFormat, QTransform,
+                             QValidator, QWhatsThisClickedEvent, QWheelEvent,
                              QWindowStateChangeEvent, qAlpha, qBlue,
-                             qFuzzyCompare, qGray, qGreen, qIsGray, qRed, qRgb,
+                             qGray, qGreen, qIsGray, qRed, qRgb,
                              qRgba, QIntValidator)
 elif PYSIDE:
     from PySide.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -26,23 +26,31 @@ elif PYQT4:
     del QStyleOptionViewItemV4
 
     # These objects belong to QtGui
+    try:
+        # Older versions of PyQt4 do not provide these
+        del (QGlyphRun,
+             QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2, QMatrix3x3,
+             QMatrix3x4, QMatrix4x2, QMatrix4x3, QMatrix4x4,
+             QQuaternion, QRadialGradient, QRawFont, QRegExpValidator,
+             QStaticText, QTouchEvent, QVector2D, QVector3D, QVector4D,
+             qFuzzyCompare)
+    except NameError:
+        pass
     del (QAbstractTextDocumentLayout, QActionEvent, QBitmap, QBrush, QClipboard,
          QCloseEvent, QColor, QConicalGradient, QContextMenuEvent, QCursor,
          QDesktopServices, QDoubleValidator, QDrag, QDragEnterEvent,
          QDragLeaveEvent, QDragMoveEvent, QDropEvent, QFileOpenEvent,
          QFocusEvent, QFont, QFontDatabase, QFontInfo, QFontMetrics,
-         QFontMetricsF, QGlyphRun, QGradient, QHelpEvent, QHideEvent,
+         QFontMetricsF, QGradient, QHelpEvent, QHideEvent,
          QHoverEvent, QIcon, QIconDragEvent, QIconEngine, QImage,
          QImageIOHandler, QImageReader, QImageWriter, QInputEvent,
          QInputMethodEvent, QKeyEvent, QKeySequence, QLinearGradient,
-         QMatrix2x2, QMatrix2x3, QMatrix2x4, QMatrix3x2, QMatrix3x3,
-         QMatrix3x4, QMatrix4x2, QMatrix4x3, QMatrix4x4, QMouseEvent,
-         QMoveEvent, QMovie, QPaintDevice, QPaintEngine, QPaintEngineState,
-         QPaintEvent, QPainter, QPainterPath, QPainterPathStroker, QPalette,
-         QPen, QPicture, QPictureIO, QPixmap, QPixmapCache, QPolygon,
-         QPolygonF, QQuaternion, QRadialGradient, QRawFont, QRegExpValidator,
+         QMouseEvent, QMoveEvent, QMovie, QPaintDevice, QPaintEngine,
+         QPaintEngineState, QPaintEvent, QPainter, QPainterPath,
+         QPainterPathStroker, QPalette, QPen, QPicture, QPictureIO, QPixmap,
+         QPixmapCache, QPolygon, QPolygonF,
          QRegion, QResizeEvent, QSessionManager, QShortcutEvent, QShowEvent,
-         QStandardItem, QStandardItemModel, QStaticText, QStatusTipEvent,
+         QStandardItem, QStandardItemModel, QStatusTipEvent,
          QSyntaxHighlighter, QTabletEvent, QTextBlock, QTextBlockFormat,
          QTextBlockGroup, QTextBlockUserData, QTextCharFormat, QTextCursor,
          QTextDocument, QTextDocumentFragment, QTextDocumentWriter,
@@ -50,9 +58,9 @@ elif PYQT4:
          QTextImageFormat, QTextInlineObject, QTextItem, QTextLayout,
          QTextLength, QTextLine, QTextList, QTextListFormat, QTextObject,
          QTextObjectInterface, QTextOption, QTextTable, QTextTableCell,
-         QTextTableCellFormat, QTextTableFormat, QTouchEvent, QTransform,
-         QValidator, QVector2D, QVector3D, QVector4D, QWhatsThisClickedEvent,
-         QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue, qFuzzyCompare,
+         QTextTableCellFormat, QTextTableFormat, QTransform,
+         QValidator, QWhatsThisClickedEvent,
+         QWheelEvent, QWindowStateChangeEvent, qAlpha, qBlue,
          qGray, qGreen, qIsGray, qRed, qRgb, qRgba, QIntValidator,
          QStringListModel)
 


### PR DESCRIPTION
PyQt4 4.6 on Centos 6.8 reports itself as:

        PyQt4.x86_64 4.6.2-9.el6 @base
        PyQt4-devel.x86_64 4.6.2-9.el6 @base

This version is missing symbols from QtGui that causes qtpy to
fail.  Allow `import qtpy` to work in this environment.

Signed-off-by: David Aguilar <davvid@gmail.com>