### PR TITLE
PR: Add tests for Qtdesigner, QtNetwork, QtPrintSupport, QtSvg and QtTest.

### DIFF
--- a/qtpy/tests/test_qtdesigner.py
+++ b/qtpy/tests/test_qtdesigner.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYSIDE2, QtDesigner
+
+
+@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
+def test_qtdesigner():
+    """Test the qtpy.QtDesigner namespace"""
+    assert QtDesigner.QAbstractExtensionFactory is not None
+    assert QtDesigner.QAbstractExtensionManager is not None
+    assert QtDesigner.QDesignerActionEditorInterface is not None
+    assert QtDesigner.QDesignerContainerExtension is not None
+    assert QtDesigner.QDesignerCustomWidgetCollectionInterface is not None
+    assert QtDesigner.QDesignerCustomWidgetInterface is not None
+    assert QtDesigner.QDesignerDynamicPropertySheetExtension is not None
+    assert QtDesigner.QDesignerFormEditorInterface is not None
+    assert QtDesigner.QDesignerFormWindowCursorInterface is not None
+    assert QtDesigner.QDesignerFormWindowInterface is not None
+    assert QtDesigner.QDesignerFormWindowManagerInterface is not None
+    assert QtDesigner.QDesignerMemberSheetExtension is not None
+    assert QtDesigner.QDesignerObjectInspectorInterface is not None
+    assert QtDesigner.QDesignerPropertyEditorInterface is not None
+    assert QtDesigner.QDesignerPropertySheetExtension is not None
+    assert QtDesigner.QDesignerTaskMenuExtension is not None
+    assert QtDesigner.QDesignerWidgetBoxInterface is not None
+    assert QtDesigner.QExtensionFactory is not None
+    assert QtDesigner.QExtensionManager is not None
+    assert QtDesigner.QFormBuilder is not None

--- a/qtpy/tests/test_qtdesigner.py
+++ b/qtpy/tests/test_qtdesigner.py
@@ -13,7 +13,6 @@ def test_qtdesigner():
     assert QtDesigner.QDesignerContainerExtension is not None
     assert QtDesigner.QDesignerCustomWidgetCollectionInterface is not None
     assert QtDesigner.QDesignerCustomWidgetInterface is not None
-    assert QtDesigner.QDesignerDynamicPropertySheetExtension is not None
     assert QtDesigner.QDesignerFormEditorInterface is not None
     assert QtDesigner.QDesignerFormWindowCursorInterface is not None
     assert QtDesigner.QDesignerFormWindowInterface is not None

--- a/qtpy/tests/test_qtdesigner.py
+++ b/qtpy/tests/test_qtdesigner.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2, QtDesigner
+from qtpy import PYSIDE2, PYSIDE
 
-
-@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
+@pytest.mark.skipif(PYSIDE2 or PYSIDE, reason="QtDesigner is not avalaible in PySide/PySide2")
 def test_qtdesigner():
+    from qtpy import QtDesigner
     """Test the qtpy.QtDesigner namespace"""
     assert QtDesigner.QAbstractExtensionFactory is not None
     assert QtDesigner.QAbstractExtensionManager is not None

--- a/qtpy/tests/test_qtnetwork.py
+++ b/qtpy/tests/test_qtnetwork.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYSIDE2, QtNetwork
+
+
+def test_qtnetwork():
+    """Test the qtpy.QtNetwork namespace"""
+    assert QtNetwork.QAbstractNetworkCache is not None
+    assert QtNetwork.QNetworkCacheMetaData is not None
+    assert QtNetwork.QHttpMultiPart is not None
+    assert QtNetwork.QHttpPart is not None
+    assert QtNetwork.QNetworkAccessManager is not None
+    assert QtNetwork.QNetworkCookie is not None
+    assert QtNetwork.QNetworkCookieJar is not None
+    assert QtNetwork.QNetworkDiskCache is not None
+    assert QtNetwork.QNetworkReply is not None
+    assert QtNetwork.QNetworkRequest is not None
+    assert QtNetwork.QNetworkConfigurationManager is not None
+    assert QtNetwork.QNetworkConfiguration is not None
+    assert QtNetwork.QNetworkSession is not None
+    assert QtNetwork.QAuthenticator is not None
+    assert QtNetwork.QDnsDomainNameRecord is not None
+    assert QtNetwork.QDnsHostAddressRecord is not None
+    assert QtNetwork.QDnsLookup is not None
+    assert QtNetwork.QDnsMailExchangeRecord is not None
+    assert QtNetwork.QDnsServiceRecord is not None
+    assert QtNetwork.QDnsTextRecord is not None
+    assert QtNetwork.QHostAddress is not None
+    assert QtNetwork.QHostInfo is not None
+    assert QtNetwork.QNetworkDatagram is not None
+    assert QtNetwork.QNetworkAddressEntry is not None
+    assert QtNetwork.QNetworkInterface is not None
+    assert QtNetwork.QNetworkProxy is not None
+    assert QtNetwork.QNetworkProxyFactory is not None
+    assert QtNetwork.QNetworkProxyQuery is not None
+    assert QtNetwork.QAbstractSocket is not None
+    assert QtNetwork.QLocalServer is not None
+    assert QtNetwork.QLocalSocket is not None
+    assert QtNetwork.QSctpServer is not None
+    assert QtNetwork.QSctpSocket is not None
+    assert QtNetwork.QTcpServer is not None
+    assert QtNetwork.QTcpSocket is not None
+    assert QtNetwork.QUdpSocket is not None
+    assert QtNetwork.QSslCertificate is not None
+    assert QtNetwork.QSslCertificateExtension is not None
+    assert QtNetwork.QSslCipher is not None
+    assert QtNetwork.QSslConfiguration is not None
+    assert QtNetwork.QSslDiffieHellmanParameters is not None
+    assert QtNetwork.QSslEllipticCurve is not None
+    assert QtNetwork.QSslError is not None
+    assert QtNetwork.QSslKey is not None
+    assert QtNetwork.QSslPreSharedKeyAuthenticator is not None
+    assert QtNetwork.QSslSocket is not None

--- a/qtpy/tests/test_qtnetwork.py
+++ b/qtpy/tests/test_qtnetwork.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2, QtNetwork
+from qtpy import PYSIDE, PYSIDE2, QtNetwork
 
 
+@pytest.mark.skipif(PYSIDE2 or PYSIDE, reason="It fails on PySide/PySide2")
 def test_qtnetwork():
     """Test the qtpy.QtNetwork namespace"""
     assert QtNetwork.QAbstractNetworkCache is not None

--- a/qtpy/tests/test_qtnetwork.py
+++ b/qtpy/tests/test_qtnetwork.py
@@ -20,15 +20,8 @@ def test_qtnetwork():
     assert QtNetwork.QNetworkConfiguration is not None
     assert QtNetwork.QNetworkSession is not None
     assert QtNetwork.QAuthenticator is not None
-    assert QtNetwork.QDnsDomainNameRecord is not None
-    assert QtNetwork.QDnsHostAddressRecord is not None
-    assert QtNetwork.QDnsLookup is not None
-    assert QtNetwork.QDnsMailExchangeRecord is not None
-    assert QtNetwork.QDnsServiceRecord is not None
-    assert QtNetwork.QDnsTextRecord is not None
     assert QtNetwork.QHostAddress is not None
     assert QtNetwork.QHostInfo is not None
-    assert QtNetwork.QNetworkDatagram is not None
     assert QtNetwork.QNetworkAddressEntry is not None
     assert QtNetwork.QNetworkInterface is not None
     assert QtNetwork.QNetworkProxy is not None
@@ -37,18 +30,12 @@ def test_qtnetwork():
     assert QtNetwork.QAbstractSocket is not None
     assert QtNetwork.QLocalServer is not None
     assert QtNetwork.QLocalSocket is not None
-    assert QtNetwork.QSctpServer is not None
-    assert QtNetwork.QSctpSocket is not None
     assert QtNetwork.QTcpServer is not None
     assert QtNetwork.QTcpSocket is not None
     assert QtNetwork.QUdpSocket is not None
     assert QtNetwork.QSslCertificate is not None
-    assert QtNetwork.QSslCertificateExtension is not None
     assert QtNetwork.QSslCipher is not None
     assert QtNetwork.QSslConfiguration is not None
-    assert QtNetwork.QSslDiffieHellmanParameters is not None
-    assert QtNetwork.QSslEllipticCurve is not None
     assert QtNetwork.QSslError is not None
     assert QtNetwork.QSslKey is not None
-    assert QtNetwork.QSslPreSharedKeyAuthenticator is not None
     assert QtNetwork.QSslSocket is not None

--- a/qtpy/tests/test_qtprintsupport.py
+++ b/qtpy/tests/test_qtprintsupport.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2, QtPrintSupport
+from qtpy import QtPrintSupport
 
 
 def test_qtprintsupport():

--- a/qtpy/tests/test_qtprintsupport.py
+++ b/qtpy/tests/test_qtprintsupport.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYSIDE2, QtPrintSupport
+
+
+def test_qtprintsupport():
+    """Test the qtpy.QtPrintSupport namespace"""
+    assert QtPrintSupport.QAbstractPrintDialog is not None
+    assert QtPrintSupport.QPageSetupDialog is not None
+    assert QtPrintSupport.QPrintDialog is not None
+    assert QtPrintSupport.QPrintPreviewDialog is not None
+    assert QtPrintSupport.QPrintEngine is not None
+    assert QtPrintSupport.QPrinter is not None
+    assert QtPrintSupport.QPrinterInfo is not None
+    assert QtPrintSupport.QPrintPreviewWidget is not None
+	
+

--- a/qtpy/tests/test_qtsvg.py
+++ b/qtpy/tests/test_qtsvg.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2, QtSvg
+from qtpy import PYSIDE2
 
-
+@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
 def test_qtsvg():
     """Test the qtpy.QtSvg namespace"""
+    from qtpy import QtSvg
+
     assert QtSvg.QGraphicsSvgItem is not None
     assert QtSvg.QSvgGenerator is not None
     assert QtSvg.QSvgRenderer is not None

--- a/qtpy/tests/test_qtsvg.py
+++ b/qtpy/tests/test_qtsvg.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYSIDE2, QtSvg
+
+
+def test_qtsvg():
+    """Test the qtpy.QtSvg namespace"""
+    assert QtSvg.QGraphicsSvgItem is not None
+    assert QtSvg.QSvgGenerator is not None
+    assert QtSvg.QSvgRenderer is not None
+    assert QtSvg.QSvgWidget is not None

--- a/qtpy/tests/test_qttest.py
+++ b/qtpy/tests/test_qttest.py
@@ -8,5 +8,3 @@ from qtpy import PYSIDE2, QtTest
 def test_qttest():
     """Test the qtpy.QtTest namespace"""
     assert QtTest.QTest is not None
-    assert QtTest.QSignalSpy is not None
-    assert QtTest.QTestEventList is not None

--- a/qtpy/tests/test_qttest.py
+++ b/qtpy/tests/test_qttest.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2, QtTest
+from qtpy import QtTest
 
 
-@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
 def test_qttest():
     """Test the qtpy.QtTest namespace"""
     assert QtTest.QTest is not None

--- a/qtpy/tests/test_qttest.py
+++ b/qtpy/tests/test_qttest.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYSIDE2, QtTest
+
+
+@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
+def test_qttest():
+    """Test the qtpy.QtTest namespace"""
+    assert QtTest.QTest is not None
+    assert QtTest.QSignalSpy is not None
+    assert QtTest.QTestEventList is not None


### PR DESCRIPTION
Fixes #110

I didn't add tests for QtOpenGL, because the usage of this module is discouraged http://doc.qt.io/qt-5/qtopengl-index.html