### PR TITLE
PR: Warn if QHeaderView deprecated methods are used

### DIFF
--- a/qtpy/_patch/qheaderview.py
+++ b/qtpy/_patch/qheaderview.py
@@ -4,6 +4,7 @@
 #
 # Licensed under the terms of the MIT License
 # (see LICENSE.txt for details)
+import warnings
 
 def introduce_renamed_methods_qheaderview(QHeaderView):
 
@@ -15,8 +16,9 @@ def introduce_renamed_methods_qheaderview(QHeaderView):
         return _isClickable(self)
     QHeaderView.sectionsClickable = sectionsClickable
     def isClickable(self):
-        raise Exception('isClickable is only available in Qt4. Use '
-                        'sectionsClickable instead.')
+        warnings.warn('isClickable is only available in Qt4. Use '
+                        'sectionsClickable instead.', stacklevel=2)
+        return _isClickable(self)
     QHeaderView.isClickable = isClickable
 
 
@@ -28,8 +30,9 @@ def introduce_renamed_methods_qheaderview(QHeaderView):
         return _isMovable(self)
     QHeaderView.sectionsMovable = sectionsMovable
     def isMovable(self):
-        raise Exception('isMovable is only available in Qt4. Use '
-                        'sectionsMovable instead.')
+        warnings.warn('isMovable is only available in Qt4. Use '
+                        'sectionsMovable instead.', stacklevel=2)
+        return _isMovable(self)
     QHeaderView.isMovable = isMovable
 
 
@@ -41,8 +44,9 @@ def introduce_renamed_methods_qheaderview(QHeaderView):
         return _resizeMode(self, logicalIndex)
     QHeaderView.sectionResizeMode = sectionResizeMode
     def resizeMode(self, logicalIndex):
-        raise Exception('resizeMode is only available in Qt4. Use '
-                        'sectionResizeMode instead.')
+        warnings.warn('resizeMode is only available in Qt4. Use '
+                        'sectionResizeMode instead.', stacklevel=2)
+        return _resizeMode(self, logicalIndex)
     QHeaderView.resizeMode = resizeMode
 
     _setClickable = QHeaderView.setClickable
@@ -53,8 +57,9 @@ def introduce_renamed_methods_qheaderview(QHeaderView):
         return _setClickable(self, clickable)
     QHeaderView.setSectionsClickable = setSectionsClickable
     def setClickable(self, clickable):
-        raise Exception('setClickable is only available in Qt4. Use '
-                        'setSectionsClickable instead.')
+        warnings.warn('setClickable is only available in Qt4. Use '
+                        'setSectionsClickable instead.', stacklevel=2)
+        return _setClickable(self, clickable)
     QHeaderView.setClickable = setClickable
 
 
@@ -66,8 +71,9 @@ def introduce_renamed_methods_qheaderview(QHeaderView):
         return _setMovable(self, movable)
     QHeaderView.setSectionsMovable = setSectionsMovable
     def setMovable(self, movable):
-        raise Exception('setMovable is only available in Qt4. Use '
-                        'setSectionsMovable instead.')
+        warnings.warn('setMovable is only available in Qt4. Use '
+                        'setSectionsMovable instead.', stacklevel=2)
+        return _setMovable(self, movable)
     QHeaderView.setMovable = setMovable
 
 
@@ -80,8 +86,9 @@ def introduce_renamed_methods_qheaderview(QHeaderView):
         _setResizeMode(self, *args)
     QHeaderView.setSectionResizeMode = setSectionResizeMode
     def setResizeMode(self, *args):
-        raise Exception('setResizeMode is only available in Qt4. Use '
-                        'setSectionResizeMode instead.')
+        warnings.warn('setResizeMode is only available in Qt4. Use '
+                        'setSectionResizeMode instead.', stacklevel=2)
+        _setResizeMode(self, *args)
     QHeaderView.setResizeMode = setResizeMode
 
 

--- a/qtpy/tests/test_patch_qheaderview.py
+++ b/qtpy/tests/test_patch_qheaderview.py
@@ -82,17 +82,17 @@ def test_patched_qheaderview():
 
     # test that the old methods in Qt4 raise exceptions
     if PYQT4 or PYSIDE:
-        with pytest.raises(Exception):
+        with pytest.warns(UserWarning):
             headerview.isClickable()
-        with pytest.raises(Exception):
+        with pytest.warns(UserWarning):
             headerview.isMovable()
-        with pytest.raises(Exception):
+        with pytest.warns(UserWarning):
             headerview.resizeMode(0)
-        with pytest.raises(Exception):
+        with pytest.warns(UserWarning):
             headerview.setClickable(True)
-        with pytest.raises(Exception):
-            headerview.setMovableClickable(True)
-        with pytest.raises(Exception):
+        with pytest.warns(UserWarning):
+            headerview.setMovable(True)
+        with pytest.warns(UserWarning):
             headerview.setResizeMode(0, QHeaderView.Interactive)
 
 


### PR DESCRIPTION
This is a second attempt at fixing #119 according to the request from @ccordoba12 in https://github.com/spyder-ide/qtpy/pull/120#issuecomment-318371899 :
Warn instead of raising an exception if QHeaderView deprecated methods
are used. Also adapt unit tests accordingly.

Fixes #119
Closes #120