### PR TITLE
PR: Changes to QDesktop split 

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -58,6 +58,7 @@ elif PYQT4:
         HomeLocation = _QDesktopServices.HomeLocation
         DataLocation = _QDesktopServices.DataLocation
         CacheLocation = _QDesktopServices.CacheLocation
+        writableLocation = _QDesktopServices.storageLocation
 
     # Those are imported from `import *`
     del pyqtSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR, qInstallMsgHandler
@@ -88,6 +89,7 @@ elif PYSIDE:
         HomeLocation = _QDesktopServices.HomeLocation
         DataLocation = _QDesktopServices.DataLocation
         CacheLocation = _QDesktopServices.CacheLocation
+        writableLocation = _QDesktopServices.storageLocation
 
     import PySide.QtCore
     __version__ = PySide.QtCore.__version__

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -12,6 +12,7 @@ Provides QtGui classes and functions.
     exposed here. Therefore, you need to treat/use this package as if it were
     the ``PyQt5.QtGui`` module.
 """
+import warnings
 
 from . import PYQT5, PYQT4, PYSIDE, PYSIDE2, PythonQtError
 
@@ -75,10 +76,21 @@ elif PYQT4:
     from PyQt4.QtGui import QDesktopServices as _QDesktopServices
 
     class QDesktopServices():
-         openUrl = _QDesktopServices.openUrl
-         setUrlHandler = _QDesktopServices.setUrlHandler
-         unsetUrlHandler = _QDesktopServices.unsetUrlHandler
+        openUrl = _QDesktopServices.openUrl
+        setUrlHandler = _QDesktopServices.setUrlHandler
+        unsetUrlHandler = _QDesktopServices.unsetUrlHandler
 
+        def __getattr__(self, name):
+            attr = getattr(_QDesktopServices, name)
+
+            new_name = name
+            if name == 'storageLocation':
+                new_name = 'writableLocation'
+            warnings.warn(("Warning QDesktopServices.{} is deprecated in Qt5"
+                            "we recommend you use QDesktopServices.{} instead").format(name, new_name),
+                           DeprecationWarning)
+            return attr
+    QDesktopServices = QDesktopServices()
 
 elif PYSIDE:
     from PySide.QtGui import (QAbstractTextDocumentLayout, QActionEvent, QBitmap,
@@ -126,8 +138,20 @@ elif PYSIDE:
     from PySide.QtGui import QDesktopServices as _QDesktopServices
 
     class QDesktopServices():
-         openUrl = _QDesktopServices.openUrl
-         setUrlHandler = _QDesktopServices.setUrlHandler
-         unsetUrlHandler = _QDesktopServices.unsetUrlHandler
+        openUrl = _QDesktopServices.openUrl
+        setUrlHandler = _QDesktopServices.setUrlHandler
+        unsetUrlHandler = _QDesktopServices.unsetUrlHandler
+
+        def __getattr__(self, name):
+            attr = getattr(_QDesktopServices, name)
+
+            new_name = name
+            if name == 'storageLocation':
+                new_name = 'writableLocation'
+            warnings.warn(("Warning QDesktopServices.{} is deprecated in Qt5"
+                            "we recommend you use QDesktopServices.{} instead").format(name, new_name),
+                           DeprecationWarning)
+            return attr
+    QDesktopServices = QDesktopServices()
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qdesktopservice_split.py
+++ b/qtpy/tests/test_qdesktopservice_split.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2
+import warnings
+from qtpy import PYQT4, PYSIDE, PYSIDE2
 
 """Test QDesktopServices split in Qt5."""
 
@@ -23,6 +24,18 @@ def test_qdesktopservice():
 
     assert QDesktopServices.setUrlHandler is not None
 
-    # Attributes from QStandardPaths shouldn't be in QDesktopServices
-    with pytest.raises(AttributeError) as excinfo:
+
+@pytest.mark.skipif(not (PYQT4 or PYSIDE), reason="Warning is only raised in old bindings")
+def test_qdesktopservice_qt4_pyside():
+    from qtpy.QtGui import QDesktopServices
+    # Attributes from QStandardPaths should raise a warning when imported
+    # from QDesktopServices
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Try to  import QtHelp.
         QDesktopServices.StandardLocation
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)


### PR DESCRIPTION
Fixes: #131
I added the missing `QtCore.QStandardPaths.writableLocation()` and allow the import of `QDesktopServices` methods in PYQT4