### PR TITLE
PR: Avoid using PyQt5.Qt, which imports unneeded stuff and forces discrete GPU on OSX

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ machine:
 dependencies:
   pre:
     # We need this for QtMultimedia in 5.8
+    - sudo apt-get update -y; true
     - sudo apt-get install libpulse-dev
     # For PySide2
     - sudo apt-get autoremove libqt5*

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -116,8 +116,8 @@ elif 'PySide' in sys.modules:
 
 if API in PYQT5_API:
     try:
-        from PyQt5.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
-        from PyQt5.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
+        from PyQt5.QtCore import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
+        from PyQt5.QtCore import QT_VERSION_STR as QT_VERSION  # analysis:ignore
         PYSIDE_VERSION = None
     except ImportError:
         API = os.environ['QT_API'] = 'pyside2'


### PR DESCRIPTION
Fixes #142