### PR TITLE
PR: Use Qt official wheels to run tests for PySide2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,16 +11,12 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      # Used by atropy ci-helpers
-      CONDA_CHANNELS: "spyder-ide qttesting"
 
   matrix:
     # Qt4
     - PYTHON_VERSION: "2.7"
       CONDA_DEPENDENCIES: "pytest pytest-cov qt=4.* pyside"
     - PYTHON_VERSION: "2.7"
-      CONDA_DEPENDENCIES: "pytest pytest-cov qt=4.* pyqt=4.*"
-    - PYTHON_VERSION: "3.4"
       CONDA_DEPENDENCIES: "pytest pytest-cov qt=4.* pyqt=4.*"
     - PYTHON_VERSION: "3.5"
       CONDA_DEPENDENCIES: "pytest pytest-cov qt=4.* pyqt=4.*"
@@ -29,6 +25,10 @@ environment:
       CONDA_DEPENDENCIES: "pytest pytest-cov qt=5.* pyqt=5.*"
     - PYTHON_VERSION: "3.5"
       CONDA_DEPENDENCIES: "pytest pytest-cov qt=5.* pyqt=5.*"
+    - PYTHON_VERSION: "3.6"
+      CONDA_DEPENDENCIES: "pytest pytest-cov"
+      PIP_DEPENDENCIES: "pyqt5==5.9.2"
+      PIP_DEPENDENCIES_FLAGS: "-q"
 
 platform:
     -x64

--- a/ci/test-pyqt4.sh
+++ b/ci/test-pyqt4.sh
@@ -3,7 +3,7 @@
 export PATH="$HOME/miniconda/bin:$PATH"
 source activate test
 
-# We use container 3 to test with pip and pyqt5
+# We use container 3 to test with pip
 if [ "$CIRCLE_NODE_INDEX" = "3" ]; then
     exit 0
 else

--- a/ci/test-pyside.sh
+++ b/ci/test-pyside.sh
@@ -3,7 +3,7 @@
 export PATH="$HOME/miniconda/bin:$PATH"
 source activate test
 
-# We use container 3 to test with pip and pyqt5
+# We use container 3 to test with pip
 if [ "$CIRCLE_NODE_INDEX" = "3" ]; then
     exit 0
 else

--- a/ci/test-pyside2.sh
+++ b/ci/test-pyside2.sh
@@ -4,26 +4,19 @@ export PATH="$HOME/miniconda/bin:$PATH"
 source activate test
 
 # Download PySide2 wheel
-wget -q https://bintray.com/fredrikaverpil/pyside2-wheels/download_file?file_path=ubuntu14.04%2FPySide2-2.0.0.dev0-cp27-none-linux_x86_64.whl -O PySide2-2.0.0.dev0-cp27-none-linux_x86_64.whl
+wget -q http://download.qt.io/snapshots/ci/pyside/5.11/latest/pyside2/PySide2-5.11.0a1-5.11.0-cp27-cp27mu-linux_x86_64.whl -O PySide2-5.11.0a1-5.11.0-cp27-cp27mu-linux_x86_64.whl
+wget -q http://download.qt.io/snapshots/ci/pyside/5.11/latest/pyside2/PySide2-5.11.0a1-5.11.0-cp36-cp36m-linux_x86_64.whl -O PySide2-5.11.0a1-5.11.0-cp36-cp36m-linux_x86_64.whl
 
-# We only use container 0 for PySide2
+# We use container 3 to test with pip
 if [ "$CIRCLE_NODE_INDEX" = "0" ]; then
     conda remove -q qt pyqt
-    pip install PySide2-2.0.0.dev0-cp27-none-linux_x86_64.whl
+    pip install PySide2-5.11.0a1-5.11.0-cp27-cp27mu-linux_x86_64.whl
+elif [ "$CIRCLE_NODE_INDEX" = "3" ]; then
+    pip uninstall -q -y pyqt5 sip
+    pip install PySide2-5.11.0a1-5.11.0-cp36-cp36m-linux_x86_64.whl
 else
     exit 0
 fi
-
-# Make symlinks for Qt libraries (else imports fail)
-pushd "$HOME/miniconda/envs/test/lib/python2.7/site-packages/PySide2/"
-
-for file in `ls Qt*x86_64-linux-gnu.so`
-do
-    symlink=${file%.x86_64-linux-gnu.so}.so
-    ln -s $file $symlink
-done
-
-popd
 
 python qtpy/tests/runtests.py
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     # Used by test scripts
     TEST_CI: "True"
     # Python versions to test (Maximum of 4 different versions for now)
-    PY_VERSIONS: "2.7 3.5 3.6 3.5"
+    PY_VERSIONS: "2.7 3.5 3.6 3.6"
     # For Coveralls
     COVERALLS_REPO_TOKEN: xh75EzxFFMoTEyNPo3wXxXv8OVkul3eE5
     # Used by astropy-ci helpers
@@ -17,13 +17,6 @@ dependencies:
     # We need this for QtMultimedia in 5.8
     - sudo apt-get update -y; true
     - sudo apt-get install libpulse-dev
-    # For PySide2
-    - sudo apt-get autoremove libqt5*
-    - sudo apt-get install apt -y
-    - sudo add-apt-repository -y ppa:beineri/opt-qt562-trusty
-    - sudo apt-get update -y; true
-    - sudo apt-get install -q qt56webengine
-    - sudo rsync -a /opt/qt56/ /usr/
 
   override:
     # First convert PY_VERSIONS to an array and then select the Python version

--- a/qtpy/QtHelp.py
+++ b/qtpy/QtHelp.py
@@ -13,14 +13,11 @@ from . import PYQT5
 from . import PYQT4
 from . import PYSIDE
 from . import PYSIDE2
-from . import PythonQtWarning
 
 if PYQT5:
     from PyQt5.QtHelp import *
 elif PYSIDE2:
-    # Current wheels don't have this module
-    # from PySide2.QtHelp
-    warnings.warn("QtHelp binding is missing in PySide2", PythonQtWarning)
+    from PySide2.QtHelp import *
 elif PYQT4:
     from PyQt4.QtHelp import *
 elif PYSIDE:

--- a/qtpy/QtMultimedia.py
+++ b/qtpy/QtMultimedia.py
@@ -4,14 +4,11 @@ from . import PYQT5
 from . import PYQT4
 from . import PYSIDE
 from . import PYSIDE2
-from . import PythonQtWarning
 
 if PYQT5:
     from PyQt5.QtMultimedia import *
 elif PYSIDE2:
-    # Current wheels don't have this module
-    # from PySide2.QtMultimedia import *
-    warnings.warn("QtMultimedia binding is missing in PySide2", PythonQtWarning)
+    from PySide2.QtMultimedia import *
 elif PYQT4:
     from PyQt4.QtMultimedia import *
     from PyQt4.QtGui import QSound

--- a/qtpy/tests/test_qdesktopservice_split.py
+++ b/qtpy/tests/test_qdesktopservice_split.py
@@ -1,12 +1,12 @@
+"""Test QDesktopServices split in Qt5."""
+
 from __future__ import absolute_import
 
 import pytest
 import warnings
-from qtpy import PYQT4, PYSIDE, PYSIDE2
+from qtpy import PYQT4, PYSIDE
 
-"""Test QDesktopServices split in Qt5."""
 
-@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
 def test_qstandarpath():
     """Test the qtpy.QStandardPaths namespace"""
     from qtpy.QtCore import QStandardPaths
@@ -17,7 +17,7 @@ def test_qstandarpath():
     with pytest.raises(AttributeError) as excinfo:
         QStandardPaths.setUrlHandler
 
-@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
+
 def test_qdesktopservice():
     """Test the qtpy.QDesktopServices namespace"""
     from qtpy.QtGui import QDesktopServices

--- a/qtpy/tests/test_qthelp.py
+++ b/qtpy/tests/test_qthelp.py
@@ -1,13 +1,10 @@
 """Test for QtHelp namespace."""
 
 from __future__ import absolute_import
-import warnings
 
 import pytest
-from qtpy import PYSIDE2, PythonQtWarning
 
 
-@pytest.mark.skipif(PYSIDE2, reason="QtHelp binding is missing in PySide2")
 def test_qthelp():
     """Test the qtpy.QtHelp namespace."""
     from qtpy import QtHelp
@@ -23,16 +20,3 @@ def test_qthelp():
     assert QtHelp.QHelpSearchQuery is not None
     assert QtHelp.QHelpSearchQueryWidget is not None
     assert QtHelp.QHelpSearchResultWidget is not None
-
-
-@pytest.mark.skipif(not PYSIDE2, reason="Only runs in not implemented bindings")
-def test_qthelp_not_implemented():
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter("always")
-        # Try to  import QtHelp.
-        from qtpy import QtHelp
-
-        assert len(w) == 1
-        assert issubclass(w[-1].category, PythonQtWarning)
-        assert "missing" in str(w[-1].message)

--- a/qtpy/tests/test_qtmultimedia.py
+++ b/qtpy/tests/test_qtmultimedia.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 
 import pytest
-import warnings
-from qtpy import PYSIDE2, PythonQtWarning
 
 
-@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
 def test_qtmultimedia():
     """Test the qtpy.QtMultimedia namespace"""
     from qtpy import QtMultimedia
@@ -15,16 +12,3 @@ def test_qtmultimedia():
     assert QtMultimedia.QAudioDeviceInfo is not None
     assert QtMultimedia.QAudioInput is not None
     assert QtMultimedia.QSound is not None
-
-
-@pytest.mark.skipif(not PYSIDE2, reason="Only runs in not implemented bindings")
-def test_qtmultimedia_not_implemented():
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter("always")
-        # Try to  import QtMultimedia.
-        from qtpy import QtMultimedia
-
-        assert len(w) == 1
-        assert issubclass(w[-1].category, PythonQtWarning)
-        assert "missing" in str(w[-1].message)

--- a/qtpy/tests/test_qtnetwork.py
+++ b/qtpy/tests/test_qtnetwork.py
@@ -4,7 +4,7 @@ import pytest
 from qtpy import PYSIDE, PYSIDE2, QtNetwork
 
 
-@pytest.mark.skipif(PYSIDE2 or PYSIDE, reason="It fails on PySide/PySide2")
+@pytest.mark.skipif(PYSIDE, reason="It fails on PySide/PySide2")
 def test_qtnetwork():
     """Test the qtpy.QtNetwork namespace"""
     assert QtNetwork.QAbstractNetworkCache is not None

--- a/qtpy/tests/test_qtnetwork.py
+++ b/qtpy/tests/test_qtnetwork.py
@@ -4,7 +4,7 @@ import pytest
 from qtpy import PYSIDE, PYSIDE2, QtNetwork
 
 
-@pytest.mark.skipif(PYSIDE, reason="It fails on PySide/PySide2")
+@pytest.mark.skipif(PYSIDE2 or PYSIDE, reason="It fails on PySide/PySide2")
 def test_qtnetwork():
     """Test the qtpy.QtNetwork namespace"""
     assert QtNetwork.QAbstractNetworkCache is not None

--- a/qtpy/tests/test_qtsvg.py
+++ b/qtpy/tests/test_qtsvg.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
 import pytest
-from qtpy import PYSIDE2
 
-@pytest.mark.skipif(PYSIDE2, reason="It fails on PySide2")
+
 def test_qtsvg():
     """Test the qtpy.QtSvg namespace"""
     from qtpy import QtSvg


### PR DESCRIPTION
This also removes some limitations for PySide2 due to our use of old wheels.