### PR TITLE
PR: Catch ValueError when trying to set sip API

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -147,7 +147,7 @@ if API in PYQT4_API:
             sip.setapi('QTextStream', 2)
             sip.setapi('QTime', 2)
             sip.setapi('QUrl', 2)
-        except AttributeError:
+        except (AttributeError, ValueError):
             # PyQt < v4.6
             pass
         from PyQt4.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore


### PR DESCRIPTION
Fixes #144.

This happens when PyQt4 was imported before qtpy