### PR TITLE
PR: Prevent warnings for equivalent APIs

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -113,13 +113,13 @@ PYQT4 = PYSIDE = PYSIDE2 = False
 
 
 if 'PyQt5' in sys.modules:
-    API = 'pyqt5'
+    API = initial_api if initial_api in PYQT5_API else 'pyqt5'
 elif 'PySide2' in sys.modules:
-    API = 'pyside2'
+    API = initial_api if initial_api in PYSIDE2_API else 'pyside2'
 elif 'PyQt4' in sys.modules:
-    API = 'pyqt4'
+    API = initial_api if initial_api in PYQT4_API else 'pyqt4'
 elif 'PySide' in sys.modules:
-    API = 'pyside'
+    API = initial_api if initial_api in PYSIDE_API else 'pyside'
 
 
 if API in PYQT5_API:


### PR DESCRIPTION
Situation: user has already imported PyQt4 and QT_API is set to pyqt.
qtpy will issue a spurious warning complaining that initial_api pyqt is different from selected one pyqt4, even if they are the same.

This code will make sure that in case of pre-loaded QT modules, the API is reset to the same initial_api if compatible, otherwise to the default.