### PR TITLE
PR: Add QtCharts module support

### DIFF
--- a/qtpy/QtCharts.py
+++ b/qtpy/QtCharts.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © 2019- The Spyder Development Team
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Provides QtChart classes and functions."""
+
+# Local imports
+from . import PYQT5, PYSIDE2, PythonQtError
+
+if PYQT5:
+    try:
+        from PyQt5 import QtChart as QtCharts
+    except ImportError:
+        raise PythonQtError('The QtChart module was not found. '
+                            'It needs to be installed separately for PyQt5.')
+elif PYSIDE2:
+    from PySide2.QtCharts import *
+else:
+    raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qtcharts.py
+++ b/qtpy/tests/test_qtcharts.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYSIDE2
+
+
+@pytest.mark.skipif(not PYSIDE2, reason="Only available by default in PySide2")
+def test_qtcharts():
+    """Test the qtpy.QtCharts namespace"""
+    from qtpy import QtCharts
+    assert QtCharts.QtCharts.QChart is not None


### PR DESCRIPTION
atm i didnt add a check whether the QtChart module for PyQt5 is installed (needs to be installed separately for PyQ5, in PySide2 it is included by default). How do you want me to do it? Simple Try-catch? Or not needed?