### PR TITLE
PR: Avoid deprecated "from collections import MutableMapping"

### DIFF
--- a/qtpy/py3compat.py
+++ b/qtpy/py3compat.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 import sys
 import os
 
-PY2 = sys.version[0] == '2'
-PY3 = sys.version[0] == '3'
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 
 
 # =============================================================================

--- a/qtpy/py3compat.py
+++ b/qtpy/py3compat.py
@@ -23,6 +23,7 @@ import os
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
+PY33 = PY3 and sys.version_info[1] >= 3
 
 
 # =============================================================================
@@ -73,7 +74,10 @@ else:
     from sys import maxsize
     import io
     import pickle
-    from collections import MutableMapping
+    if PY33:
+        from collections.abc import MutableMapping
+    else:
+        from collections import MutableMapping
     import _thread
     import reprlib
 


### PR DESCRIPTION
Silence deprecation warnings seen on Python3.7:

        qtpy/py3compat.py:76:
        DeprecationWarning: Using or importing the ABCs from 'collections'
        instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
        
            from collections import MutableMapping
