### PR TITLE
PR: Skip testing PyQt4 and PySide in Python 3.5

### DIFF
--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 export TRAVIS_OS_NAME="linux"
 export CONDA_DEPENDENCIES_FLAGS="--quiet"

--- a/.circleci/test-pyqt4.sh
+++ b/.circleci/test-pyqt4.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 source $HOME/miniconda/etc/profile.d/conda.sh
 conda activate test
@@ -11,8 +11,3 @@ else
 fi
 
 python qtpy/tests/runtests.py
-
-# Force quitting if exit status of runtests.py was not 0
-if [ $? -ne 0 ]; then
-    exit 1
-fi

--- a/.circleci/test-pyqt4.sh
+++ b/.circleci/test-pyqt4.sh
@@ -5,6 +5,10 @@ conda activate test
 
 if [ "$USE_CONDA" = "No" ]; then
     exit 0
+elif [ "$PYTHON_VERSION" = "3.5" ]; then
+    # conda-forge doesn't provide packages for
+    # Python 3.5 anymore.
+    exit 0
 else
     conda remove -q qt pyqt
     conda install -q -c conda-forge qt=4.* pyqt=4.*

--- a/.circleci/test-pyqt5.sh
+++ b/.circleci/test-pyqt5.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 source $HOME/miniconda/etc/profile.d/conda.sh
 conda activate test
@@ -26,8 +26,3 @@ else
 fi
 
 python qtpy/tests/runtests.py
-
-# Force quitting if exit status of runtests.py was not 0
-if [ $? -ne 0 ]; then
-    exit 1
-fi

--- a/.circleci/test-pyside.sh
+++ b/.circleci/test-pyside.sh
@@ -5,6 +5,10 @@ conda activate test
 
 if [ "$USE_CONDA" = "No" ]; then
     exit 0
+elif [ "$PYTHON_VERSION" = "3.5" ]; then
+    # conda-forge doesn't provide packages for
+    # Python 3.5 anymore.
+    exit 0
 else
     conda remove -q qt pyqt
     conda install -q -c conda-forge qt=4.* pyside

--- a/.circleci/test-pyside.sh
+++ b/.circleci/test-pyside.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 source $HOME/miniconda/etc/profile.d/conda.sh
 conda activate test
@@ -11,8 +11,3 @@ else
 fi
 
 python qtpy/tests/runtests.py
-
-# Force quitting if exit status of runtests.py was not 0
-if [ $? -ne 0 ]; then
-    exit 1
-fi

--- a/.circleci/test-pyside2.sh
+++ b/.circleci/test-pyside2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 source $HOME/miniconda/etc/profile.d/conda.sh
 conda activate test
@@ -12,10 +12,5 @@ else
 fi
 
 python qtpy/tests/runtests.py
-
-# Force quitting if exit status of runtests.py was not 0
-if [ $? -ne 0 ]; then
-    exit 1
-fi
 
 pip uninstall -y -q pyside2


### PR DESCRIPTION
Conda-forge doesn't provide updated packages to keep testing this.