### PR TITLE
PR: Don't load Qt3D modules for buggy versions of PySide2

### DIFF
--- a/.circleci/test-pyside2.sh
+++ b/.circleci/test-pyside2.sh
@@ -8,7 +8,9 @@ if [ "$USE_CONDA" = "Yes" ]; then
     exit 0
 else
     pip uninstall -q -y pyqt5 sip
-    pip install -q pyside2
+    # Simple solution to avoid failures with the
+    # Qt3D modules
+    pip install -q pyside2==5.12.3
 fi
 
 python qtpy/tests/runtests.py

--- a/qtpy/Qt3DAnimation.py
+++ b/qtpy/Qt3DAnimation.py
@@ -8,15 +8,19 @@
 """Provides Qt3DAnimation classes and functions."""
 
 # Local imports
-from . import PYQT5, PYSIDE2, PythonQtError
+from . import PYQT5, PYSIDE2, PythonQtError, PYSIDE_VERSION
+from .py3compat import PY2
 
 if PYQT5:
     from PyQt5.Qt3DAnimation import *
 elif PYSIDE2:
-    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
-    import PySide2.Qt3DAnimation as __temp
-    import inspect
-    for __name in inspect.getmembers(__temp.Qt3DAnimation):
-        globals()[__name[0]] = __name[1]
+    if not PY2 or (PY2 and PYSIDE_VERSION < '5.12.4'):
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+        import PySide2.Qt3DAnimation as __temp
+        import inspect
+        for __name in inspect.getmembers(__temp.Qt3DAnimation):
+            globals()[__name[0]] = __name[1]
+    else:
+        raise PythonQtError('A bug in Shiboken prevents this')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/Qt3DCore.py
+++ b/qtpy/Qt3DCore.py
@@ -8,15 +8,19 @@
 """Provides Qt3DCore classes and functions."""
 
 # Local imports
-from . import PYQT5, PYSIDE2, PythonQtError
+from . import PYQT5, PYSIDE2, PythonQtError, PYSIDE_VERSION
+from .py3compat import PY2
 
 if PYQT5:
     from PyQt5.Qt3DCore import *
 elif PYSIDE2:
-    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
-    import PySide2.Qt3DCore as __temp
-    import inspect
-    for __name in inspect.getmembers(__temp.Qt3DCore):
-        globals()[__name[0]] = __name[1]
+    if not PY2 or (PY2 and PYSIDE_VERSION < '5.12.4'):
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+        import PySide2.Qt3DCore as __temp
+        import inspect
+        for __name in inspect.getmembers(__temp.Qt3DCore):
+            globals()[__name[0]] = __name[1]
+    else:
+        raise PythonQtError('A bug in Shiboken prevents this')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/Qt3DExtras.py
+++ b/qtpy/Qt3DExtras.py
@@ -8,15 +8,19 @@
 """Provides Qt3DExtras classes and functions."""
 
 # Local imports
-from . import PYQT5, PYSIDE2, PythonQtError
+from . import PYQT5, PYSIDE2, PythonQtError, PYSIDE_VERSION
+from .py3compat import PY2
 
 if PYQT5:
     from PyQt5.Qt3DExtras import *
 elif PYSIDE2:
-    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
-    import PySide2.Qt3DExtras as __temp
-    import inspect
-    for __name in inspect.getmembers(__temp.Qt3DExtras):
-        globals()[__name[0]] = __name[1]
+    if not PY2 or (PY2 and PYSIDE_VERSION < '5.12.4'):
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+        import PySide2.Qt3DExtras as __temp
+        import inspect
+        for __name in inspect.getmembers(__temp.Qt3DExtras):
+            globals()[__name[0]] = __name[1]
+    else:
+        raise PythonQtError('A bug in Shiboken prevents this')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/Qt3DInput.py
+++ b/qtpy/Qt3DInput.py
@@ -8,15 +8,19 @@
 """Provides Qt3DInput classes and functions."""
 
 # Local imports
-from . import PYQT5, PYSIDE2, PythonQtError
+from . import PYQT5, PYSIDE2, PythonQtError, PYSIDE_VERSION
+from .py3compat import PY2
 
 if PYQT5:
     from PyQt5.Qt3DInput import *
 elif PYSIDE2:
-    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
-    import PySide2.Qt3DInput as __temp
-    import inspect
-    for __name in inspect.getmembers(__temp.Qt3DInput):
-        globals()[__name[0]] = __name[1]
+    if not PY2 or (PY2 and PYSIDE_VERSION < '5.12.4'):
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+        import PySide2.Qt3DInput as __temp
+        import inspect
+        for __name in inspect.getmembers(__temp.Qt3DInput):
+            globals()[__name[0]] = __name[1]
+    else:
+        raise PythonQtError('A bug in Shiboken prevents this')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/Qt3DLogic.py
+++ b/qtpy/Qt3DLogic.py
@@ -8,15 +8,19 @@
 """Provides Qt3DLogic classes and functions."""
 
 # Local imports
-from . import PYQT5, PYSIDE2, PythonQtError
+from . import PYQT5, PYSIDE2, PythonQtError, PYSIDE_VERSION
+from .py3compat import PY2
 
 if PYQT5:
     from PyQt5.Qt3DLogic import *
 elif PYSIDE2:
-    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
-    import PySide2.Qt3DLogic as __temp
-    import inspect
-    for __name in inspect.getmembers(__temp.Qt3DLogic):
-        globals()[__name[0]] = __name[1]
+    if not PY2 or (PY2 and PYSIDE_VERSION < '5.12.4'):
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+        import PySide2.Qt3DLogic as __temp
+        import inspect
+        for __name in inspect.getmembers(__temp.Qt3DLogic):
+            globals()[__name[0]] = __name[1]
+    else:
+        raise PythonQtError('A bug in Shiboken prevents this')
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/Qt3DRender.py
+++ b/qtpy/Qt3DRender.py
@@ -8,15 +8,19 @@
 """Provides Qt3DRender classes and functions."""
 
 # Local imports
-from . import PYQT5, PYSIDE2, PythonQtError
+from . import PYQT5, PYSIDE2, PythonQtError, PYSIDE_VERSION
+from .py3compat import PY2
 
 if PYQT5:
     from PyQt5.Qt3DRender import *
 elif PYSIDE2:
-    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
-    import PySide2.Qt3DRender as __temp
-    import inspect
-    for __name in inspect.getmembers(__temp.Qt3DRender):
-        globals()[__name[0]] = __name[1]
+    if not PY2 or (PY2 and PYSIDE_VERSION < '5.12.4'):
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+        import PySide2.Qt3DRender as __temp
+        import inspect
+        for __name in inspect.getmembers(__temp.Qt3DRender):
+            globals()[__name[0]] = __name[1]
+    else:
+        raise PythonQtError('A bug in Shiboken prevents this')
 else:
     raise PythonQtError('No Qt bindings could be found')


### PR DESCRIPTION
This is failing due to a bug in Shiboken.

Fixes #195.