### PR TITLE
PR: Add Python 3.9 compatibility for `collections.abc` module

### DIFF
--- a/qtpy/compat.py
+++ b/qtpy/compat.py
@@ -9,11 +9,10 @@ Compatibility functions
 
 from __future__ import print_function
 import sys
-import collections
 
 from . import PYQT4
 from .QtWidgets import QFileDialog
-from .py3compat import is_text_string, to_text_string, TEXT_TYPES
+from .py3compat import Callable, is_text_string, to_text_string, TEXT_TYPES
 
 
 # =============================================================================
@@ -46,7 +45,7 @@ if PYQT4:
         to PyQt API #2 and Pyside (QVariant does not exist)"""
         if PYQT_API_1:
             # PyQt API #1
-            assert isinstance(convfunc, collections.Callable)
+            assert isinstance(convfunc, Callable)
             if convfunc in TEXT_TYPES or convfunc is to_text_string:
                 return convfunc(qobj.toString())
             elif convfunc is bool:

--- a/qtpy/py3compat.py
+++ b/qtpy/py3compat.py
@@ -75,9 +75,9 @@ else:
     import io
     import pickle
     if PY33:
-        from collections.abc import MutableMapping
+        from collections.abc import Callable, MutableMapping
     else:
-        from collections import MutableMapping
+        from collections import Callable, MutableMapping
     import _thread
     import reprlib
 

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -2,7 +2,7 @@ import os
 
 from . import PYSIDE, PYSIDE2, PYQT4, PYQT5
 from .QtWidgets import QComboBox
-from .pycompat import PY33
+from .py3compat import PY33
 
 
 if PYQT5:

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -2,6 +2,7 @@ import os
 
 from . import PYSIDE, PYSIDE2, PYQT4, PYQT5
 from .QtWidgets import QComboBox
+from .pycompat import PY33
 
 
 if PYQT5:
@@ -180,8 +181,12 @@ else:
             return {}
 
         custom_widget_classes = {}
+        if PY33:
+            children = list(custom_widgets)
+        else:
+            children = custom_widgets.getchildren()
 
-        for custom_widget in custom_widgets.getchildren():
+        for custom_widget in children:
 
             cw_class = custom_widget.find('class').text
             cw_header = custom_widget.find('header').text

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -2,7 +2,6 @@ import os
 
 from . import PYSIDE, PYSIDE2, PYQT4, PYQT5
 from .QtWidgets import QComboBox
-from .py3compat import PY33
 
 
 if PYQT5:
@@ -181,12 +180,8 @@ else:
             return {}
 
         custom_widget_classes = {}
-        if PY33:
-            children = list(custom_widgets)
-        else:
-            children = custom_widgets.getchildren()
 
-        for custom_widget in children:
+        for custom_widget in custom_widgets.getchildren():
 
             cw_class = custom_widget.find('class').text
             cw_header = custom_widget.find('header').text


### PR DESCRIPTION
* Importing ABC from collections module will raise `ImportError` in Python 3.9 and raises `DeprecationWarning` from 3.4 . Hence use `collections.abc` and also preserve compatibility with Python 2. Ref : https://github.com/python/cpython/pull/10596
* ~Use `list` instead of deprecated getchildren in Python 3. #206 #238~