### PR TITLE
PR: Add support for QtSerialPort add-on

### DIFF
--- a/qtpy/QtSerialPort.py
+++ b/qtpy/QtSerialPort.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © 2020 Marcin Stano
+# Copyright © 2009- The Spyder Development Team
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Provides QtSerialPort classes and functions."""
+
+# Local imports
+from . import PYQT5, PythonQtError
+
+if PYQT5:
+    from PyQt5.QtSerialPort import *
+else:
+    raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qtserialport.py
+++ b/qtpy/tests/test_qtserialport.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYQT5
+
+@pytest.mark.skipif(not PYQT5, reason="Only available in Qt5 bindings, but still not in PySide2")
+def test_qtserialport():
+    """Test the qtpy.QtSerialPort namespace"""
+    from qtpy import QtSerialPort
+
+    assert QtSerialPort.QSerialPort is not None
+    assert QtSerialPort.QSerialPortInfo is not None


### PR DESCRIPTION
This adds support for QtSerialPort add-on. Unfortunately for now it is only available in PyQt5, not even in PySide2.