### PR TITLE
Add QtQuick1 module to support QtDeclaretive in Qt4

### DIFF
--- a/qtpy/QtQuick1.py
+++ b/qtpy/QtQuick1.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © 2009- The Spyder Development Team
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Provides QtQuick1 classes and functions."""
+
+# Local imports
+from . import PYQT4, PYSIDE, PythonQtError
+
+if PYQT4:
+    from PyQt4.QtDeclarative import *
+elif PYSIDE:
+    from PySide.QtDeclarative import *
+else:
+    raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qtquick1.py
+++ b/qtpy/tests/test_qtquick1.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import pytest
+from qtpy import PYQT4, PYSIDE
+
+@pytest.mark.skipif(not (PYQT4 or PYSIDE), reason="Only available in Qt4 bindings")
+def test_QtQuick1():
+    """Test the qtpy.QtQuick1 namespace"""
+    from qtpy import QtQuick1
+    # assert QtQuick1.ListProperty is not None
+    assert QtQuick1.QDeclarativeComponent is not None
+    assert QtQuick1.QDeclarativeContext is not None
+    assert QtQuick1.QDeclarativeEngine is not None
+    assert QtQuick1.QDeclarativeError is not None
+    assert QtQuick1.QDeclarativeExpression is not None
+    # assert QtQuick1.QDeclarativeExtensionInterface is not None
+    assert QtQuick1.QDeclarativeExtensionPlugin is not None
+    assert QtQuick1.QDeclarativeImageProvider is not None
+    assert QtQuick1.QDeclarativeItem is not None
+    assert QtQuick1.QDeclarativeNetworkAccessManagerFactory is not None
+    assert QtQuick1.QDeclarativeParserStatus is not None
+    assert QtQuick1.QDeclarativeProperty is not None
+    assert QtQuick1.QDeclarativePropertyMap is not None
+    assert QtQuick1.QDeclarativePropertyValueSource is not None
+    assert QtQuick1.QDeclarativeScriptString is not None
+    assert QtQuick1.QDeclarativeView is not None
+    # assert QtQuick1.QML_HAS_ATTACHED_PROPERTIES is not None
+    # assert QtQuick1.qmlRegisterType is not None
+    if not PYSIDE:
+        assert QtQuick1.QPyDeclarativeListProperty is not None
+        assert QtQuick1.QPyDeclarativePropertyValueSource is not None


### PR DESCRIPTION
#210 
QtDeclaretive has been replaced by the new QtQML and QtQuick modules in Qt5.  But the classes are not only named differently, but also used differently.
Qt5 used to have a Renamed QtDeclaretive called QtQuick1, but after Qt5.5 they removed that module entirely.

see https://doc.qt.io/qt-5/qtquick-porting-qt5.html#qtdeclarative-module-in-qt-5