### PR TITLE
PR: Add support for QStyleOptionFrameV3 from PyQt4

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -26,6 +26,8 @@ elif PYQT4:
     from PyQt4.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4
     del QStyleOptionViewItemV4
+    QStyleOptionFrame = QStyleOptionFrameV3
+    del QStyleOptionFrameV3
 
     # These objects belong to QtGui
     try:


### PR DESCRIPTION
In other words:
- From PyQt5 : `from PyQt5.QtWidgets import QStyleOptionFrame`
- From PyQt4: `from PyQt4.QtWidgets import QStyleOptionFrameV3`
- From QtPy: `from qtpy.QtWidgets import QStyleOptionFrame`