### PR TITLE
More informative error message

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -213,8 +213,7 @@ if API in PYSIDE_API:
         PYSIDE = True
     except ImportError:
         raise PythonQtError('No Qt bindings could be found, please install '
-                            'either PyQt5 or PySide2 (e.g. "pip install PyQt5"'
-                            ' or "pip install PySide2").')
+                            'either PyQt5 or PySide2.')
 
 # If a correct API name is passed to QT_API and it could not be found,
 # switches to another and informs through the warning

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -212,7 +212,9 @@ if API in PYSIDE_API:
         PYQT5 = PYSIDE2 = False
         PYSIDE = True
     except ImportError:
-        raise PythonQtError('No Qt bindings could be found')
+        raise PythonQtError('No Qt bindings could be found, please install '
+                            'either PyQt5 or PySide2 (e.g. "pip install PyQt5"'
+                            ' or "pip install PySide2").')
 
 # If a correct API name is passed to QT_API and it could not be found,
 # switches to another and informs through the warning


### PR DESCRIPTION
My project MNELAB depends on `qtpy` because I would like to support both `PyQt5` and `PySide2`. However, if no bindings are installed, the displayed error message could be more informative and tell users what to do (see e.g. the problem reported in https://github.com/cbrnr/mnelab/issues/182). I've added explicit instructions how to install either `PyQt5` or `PySide2`.