### PR TITLE
Add missing trove classifiers with setup-py-upgrade and setup-cfg-fmt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,37 @@
+[metadata]
+name = QtPy
+keywords = qt PyQt4 PyQt5 PySide
+url = https://github.com/spyder-ide/qtpy
+license = MIT
+author = Colin Duquesnoy, The Spyder Development Team
+author_email = goanpeca@gmail.com
+maintainer = Gonzalo Peña-Castellanos
+maintainer_email = goanpeca@gmail.com
+description = Provides an abstraction layer on top of the various Qt bindings (PyQt5, PyQt4 and PySide) and additional custom QWidgets.
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: X11 Applications :: Qt
+    Environment :: Win32 (MS Windows)
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+
+[options]
+packages = find:
+
+[options.packages.find]
+exclude =
+    contrib
+    docs
+    tests*
+
 [bdist_wheel]
-universal=1
+universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,19 @@
 [metadata]
 name = QtPy
-keywords = qt PyQt4 PyQt5 PySide
+description = Provides an abstraction layer on top of the various Qt bindings (PyQt5, PyQt4 and PySide) and additional custom QWidgets.
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/spyder-ide/qtpy
-license = MIT
 author = Colin Duquesnoy, The Spyder Development Team
 author_email = goanpeca@gmail.com
 maintainer = Gonzalo Peña-Castellanos
 maintainer_email = goanpeca@gmail.com
-description = Provides an abstraction layer on top of the various Qt bindings (PyQt5, PyQt4 and PySide) and additional custom QWidgets.
-long_description = file: README.md
-long_description_content_type = text/markdown
+license = MIT
+license_file = LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
-    Environment :: X11 Applications :: Qt
     Environment :: Win32 (MS Windows)
+    Environment :: X11 Applications :: Qt
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
@@ -23,9 +23,14 @@ classifiers =
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+keywords = qt PyQt4 PyQt5 PySide
 
 [options]
 packages = find:
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,8 @@ Setup script for qtpy
 """
 
 import os
-import io
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -16,36 +15,4 @@ version_ns = {}
 with open(os.path.join(HERE, 'qtpy', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESCRIPTION = f.read()
-
-setup(
-    name='QtPy',
-    version=version_ns['__version__'],
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    keywords=["qt PyQt4 PyQt5 PySide"],
-    url='https://github.com/spyder-ide/qtpy',
-    license='MIT',
-    author='Colin Duquesnoy, The Spyder Development Team',
-    author_email='goanpeca@gmail.com',
-    maintainer='Gonzalo Peña-Castellanos',
-    maintainer_email='goanpeca@gmail.com',
-    description='Provides an abstraction layer on top of the various Qt '
-                'bindings (PyQt5, PyQt4 and PySide) and additional custom '
-                'QWidgets.',
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type='text/markdown',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: X11 Applications :: Qt',
-        'Environment :: Win32 (MS Windows)',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5']
-)
+setup(version=version_ns['__version__'])


### PR DESCRIPTION
I noticed there were no supported python versions (py3.6, py3.7 and py3.8) in the pypi metadata