### PR TITLE
PR: Fix imported modules logic if 'FORCE_QT_API' is empty

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -116,7 +116,7 @@ PYQT4 = PYSIDE = PYSIDE2 = False
 
 # When `FORCE_QT_API` is set, we disregard
 # any previously imported python bindings.
-if os.environ.get('FORCE_QT_API') is not None:
+if not os.environ.get('FORCE_QT_API'):
     if 'PyQt5' in sys.modules:
         API = initial_api if initial_api in PYQT5_API else 'pyqt5'
     elif 'PySide2' in sys.modules:


### PR DESCRIPTION
As mentioned in #222 i stumbled across this.

before:
![Bildschirmfoto vom 2021-02-08 12-44-08](https://user-images.githubusercontent.com/5046381/107215801-19cdc680-6a0c-11eb-865a-1ded89fc365e.png)

after (expected behaviour):
![Bildschirmfoto vom 2021-02-08 12-47-17](https://user-images.githubusercontent.com/5046381/107215824-22be9800-6a0c-11eb-8a9e-c307929eb225.png)

It seems obvious to me and i spare further explination.