### PR TITLE
qtpy/tests/test_uic.py: skip if pyside2uic not installed

### DIFF
--- a/qtpy/tests/test_uic.py
+++ b/qtpy/tests/test_uic.py
@@ -3,8 +3,12 @@ import sys
 import contextlib
 
 import pytest
-from qtpy import PYQT5, PYSIDE2, QtWidgets
+from qtpy import PYQT5, PYSIDE2, PYSIDE, QtWidgets
 from qtpy.QtWidgets import QComboBox
+
+if PYSIDE2 or PYSIDE:
+    pytest.importorskip("pyside2uic", reason="pyside2uic not installed")
+
 from qtpy import uic
 from qtpy.uic import loadUi, loadUiType
 


### PR DESCRIPTION
Otherwise we get:

```
from qtpy import uic
/usr/lib/python3.8/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py:142: in _import
return original_import(name, *args, **kwargs)
qtpy/uic.py:88: in <module>
from pyside2uic import compileUi
/usr/lib/python3.8/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py:142: in _import
return original_import(name, *args, **kwargs)
E   ModuleNotFoundError: No module named 'pyside2uic'
```

This module is not guaranteed to be present since it was removed in newer versions of pyside2(-tools)

See also: https://github.com/spyder-ide/qtpy/pull/202

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>