### PR TITLE
PR: Add QShortcut class to QtWidgets module

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -24,7 +24,7 @@ elif PYQT5:
     from PyQt5.QtWidgets import *
 elif PYSIDE6:
     from PySide6.QtWidgets import *
-    from PySide6.QtGui import QAction, QActionGroup
+    from PySide6.QtGui import QAction, QActionGroup, QShortcut
     from PySide6.QtOpenGLWidgets import QOpenGLWidget
     QTextEdit.setTabStopWidth = QTextEdit.setTabStopDistance
     QTextEdit.tabStopWidth = QTextEdit.tabStopDistance


### PR DESCRIPTION
Hi, I am trying [qtawesome](https://github.com/spyder-ide/qtawesome) with PySide6.

In Qt6, QShortcut class is moved from QtWidgets module to QtGui module.
So I think QShortcut class needs to be added to QtWidgets module for Qt5 compatibility.

https://doc.qt.io/qt-5/qshortcut.html
qmake: QT += widgets

https://doc.qt.io/qt-6/qshortcut.html
qmake: QT += gui
