### PR TITLE
PR: Fix fallback API

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -182,7 +182,7 @@ if API in PYSIDE6_API:
         PYSIDE6 = True
 
     except ImportError:
-        API = os.environ['QT_API'] = 'pyqt'
+        API = os.environ['QT_API'] = 'pyqt5'
 
 
 # If a correct API name is passed to QT_API and it could not be found,


### PR DESCRIPTION
Since PyQt4 support was removed, use `pyqt5` as fallback, otherwise, if no supported API is available:
```python
qtpy/__init__.py:194: in <module>
    API_NAME = {'pyqt6': 'PyQt6', 'pyqt5': 'PyQt5',
E   KeyError: 'pyqt'
```

