### PR TITLE
PR: Reorganize `QtCharts` module import and add missing skip validation for `QtNetworkAuth` test with `PyQt6`

### DIFF
--- a/qtpy/QtCharts.py
+++ b/qtpy/QtCharts.py
@@ -11,15 +11,23 @@ from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, PythonQtError
 
 if PYQT5:
     try:
-        from PyQt5 import QtChart as QtCharts
+        from PyQt5.QtChart import *
     except ImportError:
         raise PythonQtError('The QtChart module was not found. '
                             'It needs to be installed separately for PyQt5.')
 elif PYQT6:
-    from PyQt6 import QtCharts
+    try:
+        from PyQt6.QtCharts import *
+    except ImportError:
+        raise PythonQtError('The QtCharts module was not found. '
+                            'It needs to be installed separately for PyQt6.')
 elif PYSIDE6:
-    from PySide6 import QtCharts
+    from PySide6.QtCharts import *
 elif PYSIDE2:
-    from PySide2.QtCharts import *
+    # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1026
+    import PySide2.QtCharts as __temp
+    import inspect
+    for __name in inspect.getmembers(__temp.QtCharts):
+        globals()[__name[0]] = __name[1]
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qtcharts.py
+++ b/qtpy/tests/test_qtcharts.py
@@ -1,4 +1,5 @@
 import pytest
+
 from qtpy import PYSIDE2, PYSIDE6
 
 
@@ -6,4 +7,4 @@ from qtpy import PYSIDE2, PYSIDE6
 def test_qtcharts():
     """Test the qtpy.QtCharts namespace"""
     from qtpy import QtCharts
-    assert QtCharts.QtCharts.QChart is not None
+    assert QtCharts.QChart is not None

--- a/qtpy/tests/test_qtnetworkauth.py
+++ b/qtpy/tests/test_qtnetworkauth.py
@@ -1,7 +1,9 @@
 import pytest
-from qtpy import PYQT5, PYQT6, PYSIDE2, PYSIDE6
 
-@pytest.mark.skipif(PYSIDE2 or PYQT5, reason="Not available in CI")
+from qtpy import PYQT5, PYQT6, PYSIDE2
+
+@pytest.mark.skipif(PYQT5 or PYQT6 or PYSIDE2,
+                    reason="Not available by default in PyQt. Not available for PySide2")
 def test_qtnetworkauth():
     """Test the qtpy.QtNetworkAuth namespace"""
     from qtpy import QtNetworkAuth


### PR DESCRIPTION
Fixes #257 