### PR TITLE
PR: Use modern packaging instead of deprecated distutils for version parse

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -54,7 +54,7 @@ PySide6
 
 """
 
-from distutils.version import LooseVersion
+from packaging.version import parse
 import os
 import platform
 import sys
@@ -121,15 +121,15 @@ if API in PYQT5_API:
         PYSIDE_VERSION = None
 
         if sys.platform == 'darwin':
-            macos_version = LooseVersion(platform.mac_ver()[0])
-            if macos_version < LooseVersion('10.10'):
-                if LooseVersion(QT_VERSION) >= LooseVersion('5.9'):
+            macos_version = parse(platform.mac_ver()[0])
+            if macos_version < parse('10.10'):
+                if parse(QT_VERSION) >= parse('5.9'):
                     raise PythonQtError("Qt 5.9 or higher only works in "
                                         "macOS 10.10 or higher. Your "
                                         "program will fail in this "
                                         "system.")
-            elif macos_version < LooseVersion('10.11'):
-                if LooseVersion(QT_VERSION) >= LooseVersion('5.11'):
+            elif macos_version < parse('10.11'):
+                if parse(QT_VERSION) >= parse('5.11'):
                     raise PythonQtError("Qt 5.11 or higher only works in "
                                         "macOS 10.11 or higher. Your "
                                         "program will fail in this "
@@ -160,9 +160,9 @@ if API in PYSIDE2_API:
         PYSIDE2 = True
 
         if sys.platform == 'darwin':
-            macos_version = LooseVersion(platform.mac_ver()[0])
-            if macos_version < LooseVersion('10.11'):
-                if LooseVersion(QT_VERSION) >= LooseVersion('5.11'):
+            macos_version = parse(platform.mac_ver()[0])
+            if macos_version < parse('10.11'):
+                if parse(QT_VERSION) >= parse('5.11'):
                     raise PythonQtError("Qt 5.11 or higher only works in "
                                         "macOS 10.11 or higher. Your "
                                         "program will fail in this "

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     version=version_ns['__version__'],
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     python_requires='>=3.6',
+    install_requires=['packaging'],
     keywords=["qt PyQt5 PyQt6 PySide2 PySide6"],
     url='https://github.com/spyder-ide/qtpy',
     license='MIT',


### PR DESCRIPTION
Replaces using the deprecated `distutils` for version comparison with the modern standard replacement `packaging`, and adds the latter to the `install_requires`.

Fixes #234 
Closes #235 (supersedes it)