### PR TITLE
PR: Fix and improve Coveralls reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,6 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: 'xh75EzxFFMoTEyNPo3wXxXv8OVkul3eE5'
         run: |
+          cd qtpy  # Switch to test working dir per non-src-layout hack
           python3 -m pip install --upgrade coveralls
           python3 -m coveralls --service=github-actions || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           pyside2-version: 5.12.0  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
         - os: ubuntu-latest
           python-version: '3.9'
-          use-conda: 'Yes'
+          use-conda: 'No'
           coverage: 'True'  # Collect coverage only from this run, currently
         - os: ubuntu-latest
           python-version: '3.6'
@@ -106,4 +106,5 @@ jobs:
         run: |
           cd qtpy  # Switch to test working dir per non-src-layout hack
           python3 -m pip install --upgrade coveralls
-          python3 -m coveralls --service=github --rcfile="../.coveragerc" || true
+          python3 -m coveralls --service=github --rcfile="../.coveragerc" --basedir=$(cat qtpy_basepath.txt)
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,9 @@ jobs:
         if: matrix.coverage
         shell: bash
         env:
-          COVERALLS_REPO_TOKEN: 'xh75EzxFFMoTEyNPo3wXxXv8OVkul3eE5'
+          COVERALLS_FLAG_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd qtpy  # Switch to test working dir per non-src-layout hack
           python3 -m pip install --upgrade coveralls
-          python3 -m coveralls --service=github-actions || true
+          python3 -m coveralls --service=github --rcfile="../.coveragerc" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,6 @@ jobs:
           use-conda: 'No'
           pyside2-version: 5.12.0  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
         - os: ubuntu-latest
-          python-version: '3.9'
-          use-conda: 'No'
-          coverage: 'True'  # Collect coverage only from this run, currently
-        - os: ubuntu-latest
           python-version: '3.6'
           use-conda: 'No'
           skip-pyqt6: true  # No wheels on Py 3.6 Linux CIs
@@ -67,6 +63,10 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - name: Install Linux system packages
         if: contains(matrix.os, 'ubuntu')
         shell: bash
@@ -98,13 +98,12 @@ jobs:
         if: always() && (! ((matrix.skip-pyside6) || (matrix.use-conda == 'Yes')))  # No conda packages yet for Qt6/Pyside6
         run: ./.github/workflows/test.sh pyside6
       - name: Upload coverage data to coveralls.io
-        if: matrix.coverage
         shell: bash
         env:
           COVERALLS_FLAG_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd qtpy  # Switch to test working dir per non-src-layout hack
-          python3 -m pip install --upgrade coveralls
-          python3 -m coveralls --service=github --rcfile="../.coveragerc" --basedir=$(cat qtpy_basepath.txt)
-        continue-on-error: true
+          python -m pip install --upgrade coveralls
+          cat qtpy_basedir.txt
+          python -b -X dev -m coveralls --service=github --rcfile="../.coveragerc" --basedir="$(cat qtpy_basedir.txt)"

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -40,7 +40,7 @@ fi
 
 # Build wheel of package
 git clean -xdf
-python -bb -X dev -W error setup.py sdist bdist_wheel
+python -bb -X dev setup.py sdist bdist_wheel  # Needs migration to modern PEP 517-based build backend
 
 # Install package from build wheel
 echo dist/*.whl | xargs -I % python -bb -X dev -W error -m pip install --upgrade %
@@ -49,6 +49,5 @@ echo dist/*.whl | xargs -I % python -bb -X dev -W error -m pip install --upgrade
 conda list
 
 # Run tests
-cd qtpy
+cd qtpy  # Hack to work around non-src layout pulling in local instead of installed package for cov
 python -I -bb -X dev -W error -m pytest --cov-config ../.coveragerc
-cd ..

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -55,5 +55,6 @@ conda list
 cd qtpy  # Hack to work around non-src layout pulling in local instead of installed package for cov
 python -I -bb -X dev -W error -m pytest --cov-config ../.coveragerc --cov-append
 
-# Save QtPy base path for coverage
-python -c "from pathlib import Path; import qtpy; print(Path(qtpy.__file__).parent.parent.as_posix())" > qtpy_basepath.txt
+# Save QtPy base dir for coverage
+python -c "from pathlib import Path; import qtpy; print(Path(qtpy.__file__).parent.parent.resolve().as_posix())" > qtpy_basedir.txt
+cat qtpy_basedir.txt


### PR DESCRIPTION
Coveralls is now showing 0 coverage after PR #262 . This PR will fix it, as well as implement some other low-hanging fruit fixes and improvements on top of that.

As it turns out, it was indeed due to the test working dir not matching the one coveralls was running in, due to the hacky workaround to fix the issues from QtPy having a non-`src` dir layout.

Not only does this fix the issue with coveralls, but it also makes the paths much cleaner, reports coverage from all jobs and with descriptive job names, and combines coverage across all bindings (since naturally a lot of code is specific to one binding), along with fixing/cleaning up a few other things. This makes our total coverage much higher and more representative, bringing it from 25% to 75%, a 3x improvement, as well as makes the coveralls output easier to read and more informative.

* [x] Fix coveralls reporting showing zero coverage
* [x] Improve coverage reporting
    * [x] Use .coveragerc config file
    * [x] Provide a more descriptive name for the report
    * [x] Drop repo token and use Github's instead
* [x] Collect coverage from all bindings
    * [x] Use common env name for all runs and save it
    * [x] Remove common basedir from all runs
    * [x] Combine coverage from all bindings
* [x] Collect coverage from all runners

Fix #267