### PR TITLE
PR: Upgrade packaging to avoid legacy/deprecated behavior and follow PEP 517

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       CI: 'True'
       PYTHON_VERSION: ${{ matrix.python-version }}
       USE_CONDA: ${{ matrix.use-conda }}
+      SKIP_PIP_CHECK: ${{ matrix.skip-pip-check }}
       PYQT5_VERSION: ${{ matrix.pyqt5-version }}
       PYQT6_VERSION: ${{ matrix.pyqt6-version }}
       PYSIDE2_VERSION: ${{ matrix.pyside2-version }}
@@ -43,6 +44,7 @@ jobs:
           special-invocation: 'xvfb-run --auto-servernum '
         - python-version: '3.6'
           use-conda: 'No'
+          skip-pip-check: 'true'  # Pytest packaging issue on Python 3.6 defaults channel
           pyside2-version: 5.12.0  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
         - os: ubuntu-latest
           python-version: '3.6'
@@ -104,6 +106,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd qtpy  # Switch to test working dir per non-src-layout hack
-          python -m pip install --upgrade coveralls
           cat qtpy_basedir.txt
-          python -b -X dev -m coveralls --service=github --rcfile="../.coveragerc" --basedir="$(cat qtpy_basedir.txt)"
+          pipx run coveralls --service=github --rcfile="../.coveragerc" --basedir="$(cat qtpy_basedir.txt)"

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -43,9 +43,10 @@ fi
 
 # Build wheel of package
 git clean -xdf -e *.coverage
-python -bb -X dev setup.py sdist bdist_wheel  # Needs migration to modern PEP 517-based build backend
+pip install --upgrade build
+python -bb -X dev -W error -W ignore:::pyparsing -m build
 
-# Install package from build wheel
+# Install package from built wheel
 echo dist/*.whl | xargs -I % python -bb -X dev -W error -m pip install --upgrade %
 
 # Print environment information

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -43,7 +43,7 @@ fi
 
 # Build wheel of package
 git clean -xdf -e *.coverage
-pip install --upgrade build
+python -m pip install --upgrade build
 python -bb -X dev -W error -W ignore:::pyparsing -m build
 
 # Install package from built wheel
@@ -59,3 +59,8 @@ python -I -bb -X dev -W error -m pytest --cov-config ../.coveragerc --cov-append
 # Save QtPy base dir for coverage
 python -c "from pathlib import Path; import qtpy; print(Path(qtpy.__file__).parent.parent.resolve().as_posix())" > qtpy_basedir.txt
 cat qtpy_basedir.txt
+cd ..
+
+# Check package and environment
+pipx run twine check --strict dist/*
+pip check -v || ${SKIP_PIP_CHECK:-false}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,31 +1,58 @@
-To release a new version of qtpy on PyPI:
+# Release Procedure
 
-* Close Github milestone
+To release a new version of QtPy on PyPI:
 
-* git fetch upstream && git merge upstream/master
 
-* git clean -xfdi
+## Prepare
 
-* Update CHANGELOG.md using `loghub` to generate the list of issues and PRs merged to add at the top of the file
+* Close Github milestone and ensure all issues are resolved/moved
 
-    loghub -m vX.X.X spyder-ide/qtpy
+* `git switch master && git pull upstream master` (assuming `master` is the release branch)
 
-* Update `__version__` in `__init__.py` (set release version, remove 'dev0')
+* Check `MANIFEST.in` and `setup.cfg` to ensure they are up to date
 
-* git add . && git commit -m 'Release X.X.X'
 
-* python -m build
+## Commit
 
-* twine check dist/*
+* `pip install --upgrade loghub`
 
-* twine upload dist/*
+* Update `CHANGELOG.md` using `loghub` to generate the list of issues and PRs merged to add at the top of the file:
 
-* git tag -a vX.X.X -m 'Release X.X.X'
+  ```bash
+  loghub -m vX.Y.Z spyder-ide/qtpy
+  ```
 
-* Update `__version__` in `__init__.py` (add 'dev0' and increment minor)
+* Update `__version__` in `__init__.py` (set release version, remove `.dev0`)
 
-* git add . && git commit -m 'Back to work'
+* `git commit -am 'Release X.Y.Z'`
 
-* git push
 
-* git push --tags
+## Build
+
+**Note**: We use `pip` instead of `conda` here even on Conda installs, to ensure we always get the latest upstream versions of the build dependencies.
+
+* `git clean -xfdi`
+
+* `python -m pip install --upgrade-strategy eager --upgrade build pip setuptools twine wheel`
+
+* `python -bb -X dev -W error -m build`
+
+
+## Upload
+
+* `twine check --strict dist/*`
+
+* `twine upload dist/*`
+
+* `git tag -a vX.Y.Z -m 'Release X.Y.Z'`
+
+
+## Cleanup
+
+* Update `__version__` in `__init__.py` (add `.dev0` and increment minor)
+
+* `git commit -am 'Back to work'`
+
+* `git push upstream --follow-tags`
+
+* Create a GitHub release from the tag

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,9 +14,7 @@ To release a new version of qtpy on PyPI:
 
 * git add . && git commit -m 'Release X.X.X'
 
-* python setup.py sdist
-
-* python setup.py bdist_wheel
+* python -m build
 
 * twine check dist/*
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ To release a new version of qtpy on PyPI:
 
     loghub -m vX.X.X spyder-ide/qtpy
 
-* Update `_version.py` (set release version, remove 'dev0')
+* Update `__version__` in `__init__.py` (set release version, remove 'dev0')
 
 * git add . && git commit -m 'Release X.X.X'
 
@@ -22,7 +22,7 @@ To release a new version of qtpy on PyPI:
 
 * git tag -a vX.X.X -m 'Release X.X.X'
 
-* Update `_version.py` (add 'dev0' and increment minor)
+* Update `__version__` in `__init__.py` (add 'dev0' and increment minor)
 
 * git add . && git commit -m 'Back to work'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -61,7 +61,7 @@ import sys
 import warnings
 
 # Version of QtPy
-from ._version import __version__
+__version__ = '2.0.0.dev0'
 
 
 class PythonQtError(RuntimeError):

--- a/qtpy/_version.py
+++ b/qtpy/_version.py
@@ -1,2 +1,0 @@
-version_info = (2, 0, 0, 'dev0')
-__version__ = '.'.join(map(str, version_info))

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,23 +16,33 @@ license_files =
     LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
+    Environment :: MacOS X
     Environment :: Win32 (MS Windows)
     Environment :: X11 Applications :: Qt
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: User Interfaces
+    Topic :: Software Development :: Widget Sets
 keywords = qt PyQt5 PyQt6 PySide2 PySide6
+project_urls =
+    Github = https://github.com/spyder-ide/qtpy
+    Bug Tracker = https://github.com/spyder-ide/qtpy/issues
+    Parent Project = https://www.spyder-ide.org/
 
 [options]
 packages = find:
 install_requires =
     packaging
 python_requires = >=3.6
+include_package_data = True
 zip_safe = False
 
 [options.packages.find]
@@ -40,3 +50,8 @@ exclude =
     contrib
     docs
     tests*
+
+[options.extras_require]
+test =
+    pytest>=6.0.0,<7.0
+    pytest-cov>=2.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+[metadata]
+name = QtPy
+version = attr: qtpy.__version__
+description = Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6) and additional custom QWidgets.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/spyder-ide/qtpy
+author = Colin Duquesnoy and the Spyder Development Team
+author_email = spyder.python@gmail.com
+maintainer = Spyder Development Team and QtPy Contributors
+maintainer_email = spyder.python@gmail.com
+license = MIT
+license_file = LICENSE.txt
+license_files =
+    AUTHORS.md
+    LICENSE.txt
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Win32 (MS Windows)
+    Environment :: X11 Applications :: Qt
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+keywords = qt PyQt5 PyQt6 PySide2 PySide6
+
+[options]
+packages = find:
+install_requires =
+    packaging
+python_requires = >=3.6
+zip_safe = False
+
+[options.packages.find]
+exclude =
+    contrib
+    docs
+    tests*

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-"""
-Setup script for qtpy
-"""
+"""Stub setup.py for use with legacy build tooling."""
 
-import os
+import setuptools
 
-from setuptools import setup, find_packages
-
-HERE = os.path.abspath(os.path.dirname(__file__))
-
-version_ns = {}
-with open(os.path.join(HERE, 'qtpy', '_version.py')) as f:
-    exec(f.read(), {}, version_ns)
-
-with open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESCRIPTION = f.read()
-
-setup(
-    name='QtPy',
-    version=version_ns['__version__'],
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    python_requires='>=3.6',
-    install_requires=['packaging'],
-    keywords=["qt PyQt5 PyQt6 PySide2 PySide6"],
-    url='https://github.com/spyder-ide/qtpy',
-    license='MIT',
-    author='Colin Duquesnoy and the Spyder Development Team',
-    author_email='spyder.python@gmail.com',
-    maintainer='Spyder Development Team and QtPy Contributors',
-    maintainer_email='spyder.python@gmail.com',
-    description='Provides an abstraction layer on top of the various Qt '
-                'bindings (PyQt5/6 and PySide2/6) and additional custom '
-                'QWidgets.',
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type='text/markdown',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: X11 Applications :: Qt',
-        'Environment :: Win32 (MS Windows)',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        ]
-)
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
Currently, the package is using the deprecated legacy builder and calling setup.py directly, which is causing warnings and will eventually go away completely. This migrates it to the (more) modern PEP 517 setuptools builder and setup.cfg, with a setup setup.py for backward compatibility. This also makes one change to how the version is handled to avoid having to import the package or execute any dynamic code to get the version statically, which shouldn't affect anything else as `_version` is marked as internal use only (with leading `_`). I've compared the wheels and sdists and, aside from the minor updates to the metadata made in a separate commit, they are byte for byte identical.

* [x] Update packaging for initial compatibility with PEP 517 and PEP 518
    * [x] Add pyproject.toml
    * [x] Update CIs
    * [x] Update RELEASE.md accordingly
* [x] Use modern declarative setup.cfg instead of legacy dynamically-executed setup.py
    * [x] Migrate setup.py metadata to setup.cfg
    * [x] Fix/avoid encoding issues on open()
    * [x] Run setup-cfg-format
    * [x] Add stub setup.py for backward compat with legacy tools
    * [x] More reliable static __version__ handling
    * [x] Update RELEASE,md accordingly
* [x] Add a few new bits of setup.cfg metadata
    * [x] Add additional appropriate Trove tags
    * [x] Add project urls
    * [x] Add test extra
* [x] Update RELEASE,md to follow modern PEP 517/518 best practices

Resolve #270 