### PR TITLE
PR: Prevent future deprecations messages and decrease general technical debt + code style issues

### DIFF
--- a/qtpy/QtCharts.py
+++ b/qtpy/QtCharts.py
@@ -12,15 +12,19 @@ from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, PythonQtError
 if PYQT5:
     try:
         from PyQt5.QtChart import *
-    except ImportError:
-        raise PythonQtError('The QtChart module was not found. '
-                            'It needs to be installed separately for PyQt5.')
+    except ImportError as error:
+        raise PythonQtError(
+            'The QtChart module was not found. '
+            'It needs to be installed separately for PyQt5.'
+            ) from error
 elif PYQT6:
     try:
         from PyQt6.QtCharts import *
-    except ImportError:
-        raise PythonQtError('The QtCharts module was not found. '
-                            'It needs to be installed separately for PyQt6.')
+    except ImportError as error:
+        raise PythonQtError(
+            'The QtCharts module was not found. '
+            'It needs to be installed separately for PyQt6.'
+            ) from error
 elif PYSIDE6:
     from PySide6.QtCharts import *
 elif PYSIDE2:

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -36,21 +36,21 @@ elif PYQT5:
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 
 elif PYSIDE6:
-   from PySide6.QtCore import *
-   import PySide6.QtCore
-   __version__ = PySide6.QtCore.__version__
+    from PySide6.QtCore import *
+    import PySide6.QtCore
+    __version__ = PySide6.QtCore.__version__
 
-   # obsolete in qt6
-   Qt.BackgroundColorRole = Qt.BackgroundRole
-   Qt.TextColorRole = Qt.ForegroundRole
-   Qt.MidButton = Qt.MiddleButton
+    # obsolete in qt6
+    Qt.BackgroundColorRole = Qt.BackgroundRole
+    Qt.TextColorRole = Qt.ForegroundRole
+    Qt.MidButton = Qt.MiddleButton
 
 elif PYSIDE2:
     from PySide2.QtCore import *
 
-    try:  # may be limited to PySide-5.11a1 only 
+    try:  # may be limited to PySide-5.11a1 only
         from PySide2.QtGui import QStringListModel
-    except:
+    except Exception:
         pass
 
     import PySide2.QtCore

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -65,13 +65,11 @@ from ._version import __version__
 
 
 class PythonQtError(RuntimeError):
-    """Error raise if no bindings could be selected."""
-    pass
+    """Error raised if no bindings could be selected."""
 
 
 class PythonQtWarning(Warning):
     """Warning if some features are not implemented in a binding."""
-    pass
 
 
 # Qt API environment variable name
@@ -110,7 +108,7 @@ if 'FORCE_QT_API' in os.environ:
     elif 'PyQt5' in sys.modules:
         API = initial_api if initial_api in PYQT5_API else 'pyqt5'
     elif 'PySide6' in sys.modules:
-       API = initial_api if initial_api in PYSIDE6_API else 'pyside6'
+        API = initial_api if initial_api in PYSIDE6_API else 'pyside6'
     elif 'PySide2' in sys.modules:
         API = initial_api if initial_api in PYSIDE2_API else 'pyside2'
 

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -1,7 +1,7 @@
+"""Test QtCore."""
+
 import pytest
 from qtpy import PYQT5, PYQT6, PYSIDE2, QtCore
-
-"""Test QtCore."""
 
 
 def test_qtmsghandler():

--- a/qtpy/tests/test_qtdesigner.py
+++ b/qtpy/tests/test_qtdesigner.py
@@ -3,8 +3,8 @@ from qtpy import PYSIDE2
 
 @pytest.mark.skipif(PYSIDE2, reason="QtDesigner is not avalaible in PySide2")
 def test_qtdesigner():
+    """Test the qtpy.QtDesigner namespace."""
     from qtpy import QtDesigner
-    """Test the qtpy.QtDesigner namespace"""
     assert QtDesigner.QAbstractExtensionFactory is not None
     assert QtDesigner.QAbstractExtensionManager is not None
     assert QtDesigner.QDesignerActionEditorInterface is not None

--- a/qtpy/tests/test_qtsvg.py
+++ b/qtpy/tests/test_qtsvg.py
@@ -6,7 +6,7 @@ def test_qtsvg():
     from qtpy import QtSvg
 
     if not (PYSIDE6 or PYQT6):
-         assert QtSvg.QGraphicsSvgItem is not None
-         assert QtSvg.QSvgWidget is not None
+        assert QtSvg.QGraphicsSvgItem is not None
+        assert QtSvg.QSvgWidget is not None
     assert QtSvg.QSvgGenerator is not None
     assert QtSvg.QSvgRenderer is not None

--- a/qtpy/tests/test_uic.py
+++ b/qtpy/tests/test_uic.py
@@ -28,7 +28,11 @@ def enabled_qcombobox_subclass(temp_dir_path):
     and then removes it once we are done.
     """
 
-    with open(temp_dir_path / 'qcombobox_subclass.py', 'w') as f:
+    with open(
+            temp_dir_path / 'qcombobox_subclass.py',
+            mode='w',
+            encoding="utf-8",
+            ) as f:
         f.write(QCOMBOBOX_SUBCLASS)
 
     sys.path.insert(0, str(temp_dir_path))

--- a/qtpy/tests/test_uic.py
+++ b/qtpy/tests/test_uic.py
@@ -22,16 +22,16 @@ class _QComboBoxSubclass(QComboBox):
 """
 
 @contextlib.contextmanager
-def enabled_qcombobox_subclass(tmpdir):
+def enabled_qcombobox_subclass(temp_dir_path):
     """
     Context manager that sets up a temporary module with a QComboBox subclass
     and then removes it once we are done.
     """
 
-    with open(tmpdir.join('qcombobox_subclass.py').strpath, 'w') as f:
+    with open(temp_dir_path / 'qcombobox_subclass.py', 'w') as f:
         f.write(QCOMBOBOX_SUBCLASS)
 
-    sys.path.insert(0, tmpdir.strpath)
+    sys.path.insert(0, str(temp_dir_path))
 
     yield
 
@@ -106,7 +106,7 @@ def test_load_ui_type():
     os.environ.get('CI', None) is not None
     and sys.platform.startswith('linux'),
     reason="Segfaults on Linux CIs under all bindings (PYSIDE2/6 & PYQT5/6)")
-def test_load_ui_custom_auto(tmpdir):
+def test_load_ui_custom_auto(tmp_path):
     """
     Test that we can load a .ui file with custom widgets without having to
     explicitly specify a dictionary of custom widgets, even in the case of
@@ -115,7 +115,7 @@ def test_load_ui_custom_auto(tmpdir):
 
     app = get_qapp()
 
-    with enabled_qcombobox_subclass(tmpdir):
+    with enabled_qcombobox_subclass(tmp_path):
         from qcombobox_subclass import _QComboBoxSubclass
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/qtpy/tests/test_uic.py
+++ b/qtpy/tests/test_uic.py
@@ -140,4 +140,4 @@ def test_load_full_uic():
     else:
         objects = ['compileUi', 'compileUiDir', 'loadUi', 'loadUiType',
                    'widgetPluginPath']
-        assert all([hasattr(uic, o) for o in objects])
+        assert all((hasattr(uic, o) for o in objects))

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -254,7 +254,7 @@ else:
         widget_class = ui.find('widget').get('class')
         form_class = ui.find('class').text
 
-        with open(uifile) as fd:
+        with open(uifile, encoding="utf-8") as fd:
             code_stream = StringIO()
             frame = {}
 

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -152,9 +152,11 @@ else:
                     # customWidgets is empty.
                     try:
                         widget = self.customWidgets[class_name](parent)
-                    except KeyError:
-                        raise Exception('No custom widget ' + class_name + ' '
-                                        'found in customWidgets')
+                    except KeyError as error:
+                        raise Exception(
+                            f'No custom widget {class_name} '
+                            'found in customWidgets'
+                            ) from error
 
                 if self.baseinstance:
                     # set an attribute for the new child widget on the base


### PR DESCRIPTION
Fixes a number of minor problems in the codebase, including:

* [x] Replace the deprecated `tmpdir` pytest fixture which uses legacy py.path objects with `tmp_path`, which uses standard `pathlib.Path`s (and rename helper function arg to avoid confusion)
* [x] Use explicit `encoding` on `open()`, to avoid platform/environment-dependent bugs, deprecation warning on Py3.10 and eventual removal
* [x] Fix other correctness issues, including:
    * [x] Bad indent levels in some lines/blocks
    * [x] Missing `raise from` on re-raised exceptions to re-raise correctly
    * [x] Bare except that will trap KeyboardInterrupt, termination and other unwanted errors
    * [x] Misplaced strings intended as docstrings but not the first line in their module/callable