### PR TITLE
PR: Fix regression in FORCE_QT_API behavior from merging PySide6 support

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -100,9 +100,8 @@ is_old_pyqt = is_pyqt46 = False
 PYQT5 = True
 PYQT6 = PYSIDE2 = PYSIDE6 = False
 
-# When `FORCE_QT_API` is set, we disregard
-# any previously imported python bindings.
-if 'FORCE_QT_API' in os.environ:
+# Unless `FORCE_QT_API` is set, we use previousl imported python bindings.
+if not os.environ.get('FORCE_QT_API'):
     if 'PyQt6' in sys.modules:
         API = initial_api if initial_api in PYQT6_API else 'pyqt6'
     elif 'PyQt5' in sys.modules:

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -100,7 +100,7 @@ is_old_pyqt = is_pyqt46 = False
 PYQT5 = True
 PYQT6 = PYSIDE2 = PYSIDE6 = False
 
-# Unless `FORCE_QT_API` is set, we use previously imported python bindings.
+# Unless `FORCE_QT_API` is set, use previously imported Qt Python bindings
 if not os.environ.get('FORCE_QT_API'):
     if 'PyQt6' in sys.modules:
         API = initial_api if initial_api in PYQT6_API else 'pyqt6'

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -100,7 +100,7 @@ is_old_pyqt = is_pyqt46 = False
 PYQT5 = True
 PYQT6 = PYSIDE2 = PYSIDE6 = False
 
-# Unless `FORCE_QT_API` is set, we use previousl imported python bindings.
+# Unless `FORCE_QT_API` is set, we use previously imported python bindings.
 if not os.environ.get('FORCE_QT_API'):
     if 'PyQt6' in sys.modules:
         API = initial_api if initial_api in PYQT6_API else 'pyqt6'


### PR DESCRIPTION
#225 somehow reverted the fix for the broken `FORCE_QT_API` that was fixed in #230.  presumably a merge fail... not sure if there are others

on current master (this pretty much destroys environments with multiple Qt backends)

```py
In [1]: import PySide6

In [2]: from qtpy import QtCore

In [3]: QtCore.QTimer
Out[3]: PyQt6.QtCore.QTimer
```