### PR TITLE
PR: Add back legacy PYQT4 and PYSIDE package-level constants for compat

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -98,7 +98,7 @@ assert API in (PYQT5_API + PYQT6_API + PYSIDE2_API + PYSIDE6_API)
 
 is_old_pyqt = is_pyqt46 = False
 PYQT5 = True
-PYQT6 = PYSIDE2 = PYSIDE6 = False
+PYQT4 = PYQT6 = PYSIDE = PYSIDE2 = PYSIDE6 = False
 
 # Unless `FORCE_QT_API` is set, use previously imported Qt Python bindings
 if not os.environ.get('FORCE_QT_API'):


### PR DESCRIPTION
As discussed in [#85 (comment)](https://github.com/spyder-ide/qtpy/issues/85#issuecomment-963393873), especially if we're going to keep around old non-constant top-level variables that were only used internally (`is_old_pyqt` and `is_pyqt46`), we may as well keep the `PYQT4` and `PYSIDE` module-level constants around (always `False` now) for backward compatibility, and easier cross-compat between QtPy versions.