### PR TITLE
PR: Import Callable and MutableMapping in py3compat for Python 2 compat

### DIFF
--- a/qtpy/py3compat.py
+++ b/qtpy/py3compat.py
@@ -46,6 +46,7 @@ NUMERIC_TYPES = tuple(list(INT_TYPES) + [float, complex])
 if PY2:
     # Python 2
     import __builtin__ as builtins
+    from collections import Callable, MutableMapping
     import ConfigParser as configparser
     try:
         import _winreg as winreg


### PR DESCRIPTION
The PY2 code path was not importing Callable, which breaks the
compat module when it tries to import Callable from py3compat.

Signed-off-by: David Aguilar <davvid@gmail.com>