### PR TITLE
PR: Map exec_ to their non-deprecated alternatives

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -61,6 +61,12 @@ elif PYSIDE6:
     Qt.TextColorRole = Qt.ForegroundRole
     Qt.MidButton = Qt.MiddleButton
 
+    # Map DeprecationWarning methods
+    QCoreApplication.exec_ = QCoreApplication.exec
+    QEventLoop.exec_ = QEventLoop.exec
+    QThread.exec_ = QThread.exec
+    QTextStreamManipulator.exec_ = QTextStreamManipulator.exec
+
 elif PYSIDE2:
     from PySide2.QtCore import *
 

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -12,7 +12,7 @@ from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, PythonQtError
 
 
 if PYQT6:
-    from PyQt6 import QtGui 
+    from PyQt6 import QtGui
     from PyQt6.QtGui import *
 
     # Map missing/renamed methods
@@ -31,5 +31,9 @@ elif PYSIDE2:
 elif PYSIDE6:
     from PySide6.QtGui import *
     QFontMetrics.width = QFontMetrics.horizontalAdvance
+
+    # Map DeprecationWarning methods
+    QDrag.exec_ = QDrag.exec
+    QGuiApplication.exec_ = QGuiApplication.exec
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtPrintSupport.py
+++ b/qtpy/QtPrintSupport.py
@@ -20,6 +20,9 @@ elif PYQT6:
     QPrintPreviewWidget.print_ = QPrintPreviewWidget.print
 elif PYSIDE6:
     from PySide6.QtPrintSupport import *
+    # Map DeprecationWarning methods
+    QPageSetupDialog.exec_ = QPageSetupDialog.exec
+    QPrintDialog.exec_ = QPrintDialog.exec
 elif PYSIDE2:
     from PySide2.QtPrintSupport import *
 else:

--- a/qtpy/QtSql.py
+++ b/qtpy/QtSql.py
@@ -18,6 +18,10 @@ elif PYQT6:
     QSqlResult.exec_ = QSqlResult.exec
 elif PYSIDE6:
     from PySide6.QtSql import *
+    # Map DeprecationWarning methods
+    QSqlDatabase.exec_ = QSqlDatabase.exec
+    QSqlQuery.exec_ = QSqlQuery.exec
+    QSqlResult.exec_ = QSqlResult.exec
 elif PYSIDE2:
     from PySide2.QtSql import *
 else:

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -44,6 +44,11 @@ elif PYSIDE6:
     QTextEdit.tabStopWidth = QTextEdit.tabStopDistance
     QPlainTextEdit.setTabStopWidth = QPlainTextEdit.setTabStopDistance
     QPlainTextEdit.tabStopWidth = QPlainTextEdit.tabStopDistance
+
+    # Map DeprecationWarning methods
+    QApplication.exec_ = QApplication.exec
+    QDialog.exec_ = QDialog.exec
+    QMenu.exec_ = QMenu.exec
 elif PYSIDE2:
     from PySide2.QtWidgets import *
 else:


### PR DESCRIPTION
This PR fixes #286.

All `exec_`s of PySide6 are simply mapped (assigned) to `exec`s to avoid the following DeprecationWarning of PySide6.

```
DeprecationWarning: 'exec_' will be removed in the future. Use 'exec' instead.
  sys.exit(app.exec_())
```

I think if there is no problem if `exec_` is overwritten, this PR can be merged.
If a way to access the original `exec_` is required, QtPy may provides the option for controlling the overwrite or the special attribute for accessing original `exec_`.



