### PR TITLE
PR: Import all classes in QtTest module.

### DIFF
--- a/qtpy/QtTest.py
+++ b/qtpy/QtTest.py
@@ -12,12 +12,18 @@ Provides QtTest and functions
 from . import PYQT5, PYQT6, PYSIDE6, PYSIDE2, PythonQtError
 
 if PYQT6:
-    from PyQt6.QtTest import QTest
+    from PyQt6 import QtTest
+    from PyQt6.QtTest import *
+
+    # Allow unscoped access for enums inside the QtTest module
+    from .enums_compat import promote_enums
+    promote_enums(QtTest)
+    del QtTest
 elif PYQT5:
-    from PyQt5.QtTest import QTest
+    from PyQt5.QtTest import *
 elif PYSIDE6:
-    from PySide6.QtTest import QTest
+    from PySide6.QtTest import *
 elif PYSIDE2:
-    from PySide2.QtTest import QTest
+    from PySide2.QtTest import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qttest.py
+++ b/qtpy/tests/test_qttest.py
@@ -1,7 +1,22 @@
 import pytest
-from qtpy import QtTest
+from packaging import version
+from qtpy import QtTest, PYQT5, PYQT6, PYSIDE6, PYQT_VERSION
 
 
 def test_qttest():
     """Test the qtpy.QtTest namespace"""
     assert QtTest.QTest is not None
+
+    if PYQT5 or PYQT6 or PYSIDE6:
+        assert QtTest.QSignalSpy is not None
+
+        if (PYQT5 and version.parse(PYQT_VERSION) >= version.parse('5.11')) or PYQT6 or PYSIDE6:
+            assert QtTest.QAbstractItemModelTester is not None
+
+
+@pytest.mark.skipif(PYQT5 and PYQT_VERSION.startswith('5.9'),
+                    reason="A specific setup with at least sip 4.9.9 is needed for PyQt5 5.9.*"
+                           "to work with scoped enum access")
+def test_enum_access():
+    """Test scoped and unscoped enum access for qtpy.QtTest.*."""
+    assert QtTest.QTest.Click == QtTest.QTest.KeyAction.Click


### PR DESCRIPTION
I made this PR to fix #197.

I use promote_enums  in QtTest.
In Current QtPy, promote_enums is used in QtCore/QtGui/QtWidgets only, but is there any reason?
