### PR TITLE
PR: Add QtTextToSpeech Module

### DIFF
--- a/qtpy/QtTextToSpeech.py
+++ b/qtpy/QtTextToSpeech.py
@@ -1,0 +1,16 @@
+# -----------------------------------------------------------------------------
+# Copyright © 2009- The Spyder Development Team
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Provides QtTextToSpeech classes and functions."""
+
+from . import PYQT5, PYSIDE2, PythonQtError
+
+if PYQT5:
+    from PyQt5.QtTextToSpeech import *
+elif PYSIDE2:
+    from PySide2.QtTextToSpeech import *
+else:
+    raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/tests/test_qttexttospeech.py
+++ b/qtpy/tests/test_qttexttospeech.py
@@ -1,0 +1,16 @@
+import pytest
+from packaging import version
+from qtpy import PYQT5, PYSIDE2, PYQT_VERSION
+
+
+@pytest.mark.skipif(not ((PYQT5 and version.parse(PYQT_VERSION) >= version.parse('5.15.1')) or PYSIDE2),
+                    reason="Only available in Qt5 bindings (PyQt5 >= 5.15.1 or PySide2)")
+def test_qttexttospeech():
+    """Test the qtpy.QtTextToSpeech namespace."""
+    from qtpy import QtTextToSpeech
+
+    assert QtTextToSpeech.QTextToSpeech is not None
+    assert QtTextToSpeech.QVoice is not None
+
+    if PYSIDE2:
+        assert QtTextToSpeech.QTextToSpeechEngine is not None


### PR DESCRIPTION
I made this PR to support #232.
Note that QtTextToSpeech is available in Qt5 only and has not been supported in Qt6 yet.

https://www.qt.io/product/qt6/qt-5-15-vs-6-2-feature-comparison
> Qt Speech
> Due to its limited adoption in Qt 5, we are still studying whether to port this add-on module to Qt 6. Please let us know whether and how you are using this module. Existing projects can pull the relevant code from the 5.15 branch into their project.

And, PyQt5 >= 5.15.1 or PySide2 (>= first 5.11.0) supports QtTextToSpeech.

The copyright and license part in QtTextToSpeech.py is copy of QtXml.py.