### PR TITLE
PR: Define Qt/binding versions at top level, fix warnings if versions not found, and fix test dir on CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,6 @@ jobs:
           COVERALLS_FLAG_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd qtpy  # Switch to test working dir per non-src-layout hack
+          cd temp_test_dir  # Switch to test working dir per non-src-layout hack
           cat qtpy_basedir.txt
           pipx run coveralls --service=github --rcfile="../.coveragerc" --basedir="$(cat qtpy_basedir.txt)"

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -53,13 +53,14 @@ echo dist/*.whl | xargs -I % python -bb -X dev -W error -m pip install --upgrade
 conda list
 
 # Run tests
-cd qtpy  # Hack to work around non-src layout pulling in local instead of installed package for cov
-python -I -bb -X dev -W error -m pytest --cov-config ../.coveragerc --cov-append
+mkdir -p temp_test_dir
+pushd temp_test_dir # Hack to work around non-src layout pulling in local instead of installed package for cov
+python -I -bb -X dev -W error -m pytest ../qtpy --cov-config ../.coveragerc --cov-append
 
 # Save QtPy base dir for coverage
 python -c "from pathlib import Path; import qtpy; print(Path(qtpy.__file__).parent.parent.resolve().as_posix())" > qtpy_basedir.txt
 cat qtpy_basedir.txt
-cd ..
+popd
 
 # Check package and environment
 pipx run twine check --strict dist/*

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -105,6 +105,10 @@ is_old_pyqt = is_pyqt46 = False
 PYQT5 = True
 PYQT4 = PYQT6 = PYSIDE = PYSIDE2 = PYSIDE6 = False
 
+PYQT_VERSION = None
+PYSIDE_VERSION = None
+QT_VERSION = None
+
 # Unless `FORCE_QT_API` is set, use previously imported Qt Python bindings
 if not os.environ.get('FORCE_QT_API'):
     if 'PyQt6' in sys.modules:
@@ -120,7 +124,6 @@ if API in PYQT5_API:
     try:
         from PyQt5.QtCore import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
         from PyQt5.QtCore import QT_VERSION_STR as QT_VERSION  # analysis:ignore
-        PYSIDE_VERSION = None
 
         if sys.platform == 'darwin':
             macos_version = parse(platform.mac_ver()[0])
@@ -145,7 +148,6 @@ if API in PYQT6_API:
     try:
         from PyQt6.QtCore import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
         from PyQt6.QtCore import QT_VERSION_STR as QT_VERSION  # analysis:ignore
-        PYSIDE_VERSION = None
         PYQT5 = False
         PYQT6 = True
     except ImportError:
@@ -157,7 +159,6 @@ if API in PYSIDE2_API:
         from PySide2 import __version__ as PYSIDE_VERSION  # analysis:ignore
         from PySide2.QtCore import __version__ as QT_VERSION  # analysis:ignore
 
-        PYQT_VERSION = None
         PYQT5 = False
         PYSIDE2 = True
 
@@ -179,7 +180,6 @@ if API in PYSIDE6_API:
         from PySide6 import __version__ as PYSIDE_VERSION  # analysis:ignore
         from PySide6.QtCore import __version__ as QT_VERSION  # analysis:ignore
 
-        PYQT_VERSION = None
         PYQT5 = False
         PYSIDE6 = True
 
@@ -215,7 +215,7 @@ def _warn_old_minor_version(name, old_version, min_version):
 
 
 # Warn if using an End of Life, unsupported Qt API/binding
-if parse(QT_VERSION) < parse(QT_VERSION_MIN):
+if QT_VERSION and parse(QT_VERSION) < parse(QT_VERSION_MIN):
     _warn_old_minor_version('Qt', QT_VERSION, QT_VERSION_MIN)
 if PYQT_VERSION and parse(PYQT_VERSION) < parse(PYQT_VERSION_MIN):
     _warn_old_minor_version('PyQt', PYQT_VERSION, PYQT_VERSION_MIN)


### PR DESCRIPTION
Followup to merging PR #289 to `master` following a very weird and unexpected check failure on Win 10 + PyQt 5.9 + conda + Python 3.6; see [CI logs](https://github.com/spyder-ide/qtpy/pull/292#issue-793185869).

Seems like there's some weird behavior on this very specific CI run, where the tests pass, but when we run the command to save the path for the test coverage, which imports QtPy a _second_ time in a new instance of the same interpreter, `QT_VERSION` is not defined, which must mean that all the `if` blocks either didn't trigger or had an `ImportError` and QtPy fell back to using PyQt5. I could understand if PyQt 5.9 didn't define those top-level constants (since the source repo is not public, I tried to check beforehand but couldn't), but the fact that it worked without error the first time for the tests leads me to believe that it must either have been something with setting the env variables that triggered the different behavior on the second, or there's something else I'm not accounting for going on.

EDIT: It was the latter, the second Python command was run without `-I` which resulted in shadowing due to the hack I used to avoid problems due to the non-src directory layout. See below for full details.

~While this PR fixes the proximate error and ensures that the top-level constants are always at least defined, I want to see if I can reproduce this locally in the same env, as it may indicate an underlying issue.~ Done, see below.

So, this PR implements three levels of fixes to the related issues discovered here:

- [x] Checks that `QT_VERSION` is defined first before acting on it (like all the others)
- [x] Initializes the top-level version constants to `None` at the top of the file, which avoids them being undefined if no Qt API is found and also reduces duplication and verbosity
- [x] Fixes the shadowing issue in the tests that surfaced this behavior to begin with