### PR TITLE
PR: Add minimum version check for Qt6 >=6.2.0

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -106,8 +106,8 @@ initial_api = API
 assert API in (PYQT5_API + PYQT6_API + PYSIDE2_API + PYSIDE6_API)
 
 is_old_pyqt = is_pyqt46 = False
-PYQT5 = True
-PYQT4 = PYQT6 = PYSIDE = PYSIDE2 = PYSIDE6 = False
+QT5 = PYQT5 = True
+QT4 = QT6 = PYQT4 = PYQT6 = PYSIDE = PYSIDE2 = PYSIDE6 = False
 
 PYQT_VERSION = None
 PYSIDE_VERSION = None
@@ -128,6 +128,8 @@ if API in PYQT5_API:
     try:
         from PyQt5.QtCore import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
         from PyQt5.QtCore import QT_VERSION_STR as QT_VERSION  # analysis:ignore
+
+        QT5 = PYQT5 = True
 
         if sys.platform == 'darwin':
             macos_version = parse(platform.mac_ver()[0])
@@ -152,8 +154,10 @@ if API in PYQT6_API:
     try:
         from PyQt6.QtCore import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
         from PyQt6.QtCore import QT_VERSION_STR as QT_VERSION  # analysis:ignore
-        PYQT5 = False
-        PYQT6 = True
+
+        QT5 = PYQT5 = False
+        QT6 = PYQT6 = True
+
     except ImportError:
         API = os.environ['QT_API'] = 'pyside2'
 
@@ -164,7 +168,7 @@ if API in PYSIDE2_API:
         from PySide2.QtCore import __version__ as QT_VERSION  # analysis:ignore
 
         PYQT5 = False
-        PYSIDE2 = True
+        QT5 = PYSIDE2 = True
 
         if sys.platform == 'darwin':
             macos_version = parse(platform.mac_ver()[0])
@@ -184,8 +188,8 @@ if API in PYSIDE6_API:
         from PySide6 import __version__ as PYSIDE_VERSION  # analysis:ignore
         from PySide6.QtCore import __version__ as QT_VERSION  # analysis:ignore
 
-        PYQT5 = False
-        PYSIDE6 = True
+        QT5 = PYQT5 = False
+        QT6 = PYSIDE6 = True
 
     except ImportError:
         API = os.environ['QT_API'] = 'pyqt5'
@@ -203,7 +207,7 @@ API_NAME = {'pyqt6': 'PyQt6', 'pyqt5': 'PyQt5',
 try:
     # QtDataVisualization backward compatibility (QtDataVisualization vs. QtDatavisualization)
     # Only available for Qt5 bindings > 5.9 on Windows
-    from . import QtDataVisualization as QtDatavisualization
+    from . import QtDataVisualization as QtDatavisualization  # analysis:ignore
 except (ImportError, PythonQtError):
     pass
 
@@ -211,8 +215,8 @@ except (ImportError, PythonQtError):
 def _warn_old_minor_version(name, old_version, min_version):
     """Warn if using a Qt or binding version no longer supported by QtPy."""
     warning_message = (
-        "{name} version {old_version} is not supported upstream or "
-        "by QtPy 2.0. To ensure your application works correctly with QtPy, "
+        "{name} version {old_version} is not supported by QtPy. "
+        "To ensure your application works correctly with QtPy, "
         "please upgrade to {name} {min_version} or later.".format(
             name=name, old_version=old_version, min_version=min_version))
     warnings.warn(warning_message, PythonQtWarning)
@@ -220,17 +224,18 @@ def _warn_old_minor_version(name, old_version, min_version):
 
 # Warn if using an End of Life or unsupported Qt API/binding minor version
 if QT_VERSION:
-    if parse(QT_VERSION) < parse(QT5_VERSION_MIN):
+    if QT5 and (parse(QT_VERSION) < parse(QT5_VERSION_MIN)):
         _warn_old_minor_version('Qt5', QT_VERSION, QT5_VERSION_MIN)
-    elif parse('6') <= parse(QT_VERSION) < parse(QT6_VERSION_MIN):
+    elif QT6 and (parse(QT_VERSION) < parse(QT6_VERSION_MIN)):
         _warn_old_minor_version('Qt6', QT_VERSION, QT6_VERSION_MIN)
+
 if PYQT_VERSION:
-    if parse(PYQT_VERSION) < parse(PYQT5_VERSION_MIN):
+    if PYQT5 and (parse(PYQT_VERSION) < parse(PYQT5_VERSION_MIN)):
         _warn_old_minor_version('PyQt5', PYQT_VERSION, PYQT5_VERSION_MIN)
-    elif parse('6') <= parse(PYQT_VERSION) < parse(PYQT6_VERSION_MIN):
+    elif PYQT6 and (parse(PYQT_VERSION) < parse(PYQT6_VERSION_MIN)):
         _warn_old_minor_version('PyQt6', PYQT_VERSION, PYQT6_VERSION_MIN)
 elif PYSIDE_VERSION:
-    if parse(PYSIDE_VERSION) < parse(PYSIDE2_VERSION_MIN):
+    if PYSIDE2 and (parse(PYSIDE_VERSION) < parse(PYSIDE2_VERSION_MIN)):
         _warn_old_minor_version('PySide2', PYSIDE_VERSION, PYSIDE2_VERSION_MIN)
-    elif parse('6') <= parse(PYSIDE_VERSION) < parse(PYSIDE6_VERSION_MIN):
+    elif PYSIDE6 and (parse(PYSIDE_VERSION) < parse(PYSIDE6_VERSION_MIN)):
         _warn_old_minor_version('PySide6', PYSIDE_VERSION, PYSIDE6_VERSION_MIN)

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -87,9 +87,13 @@ PYSIDE2_API = ['pyside2']
 PYSIDE6_API = ['pyside6']
 
 # Minimum supported versions of Qt and the bindings
-PYQT_VERSION_MIN = '5.9.0'
-PYSIDE_VERSION_MIN = '5.12.0'
-QT_VERSION_MIN = '5.9.0'
+QT5_VERSION_MIN = PYQT5_VERSION_MIN = '5.9.0'
+PYSIDE2_VERSION_MIN = '5.12.0'
+QT6_VERSION_MIN = PYQT6_VERSION_MIN = PYSIDE6_VERSION_MIN = '6.2.0'
+
+QT_VERSION_MIN = QT5_VERSION_MIN
+PYQT_VERSION_MIN = PYQT5_VERSION_MIN
+PYSIDE_VERISION_MIN = PYSIDE2_VERSION_MIN
 
 # Detecting if a binding was specified by the user
 binding_specified = QT_API in os.environ
@@ -207,17 +211,26 @@ except (ImportError, PythonQtError):
 def _warn_old_minor_version(name, old_version, min_version):
     """Warn if using a Qt or binding version no longer supported by QtPy."""
     warning_message = (
-        "{name} version {old_version} is no longer supported upstream or "
+        "{name} version {old_version} is not supported upstream or "
         "by QtPy 2.0. To ensure your application works correctly with QtPy, "
         "please upgrade to {name} {min_version} or later.".format(
             name=name, old_version=old_version, min_version=min_version))
     warnings.warn(warning_message, PythonQtWarning)
 
 
-# Warn if using an End of Life, unsupported Qt API/binding
-if QT_VERSION and parse(QT_VERSION) < parse(QT_VERSION_MIN):
-    _warn_old_minor_version('Qt', QT_VERSION, QT_VERSION_MIN)
-if PYQT_VERSION and parse(PYQT_VERSION) < parse(PYQT_VERSION_MIN):
-    _warn_old_minor_version('PyQt', PYQT_VERSION, PYQT_VERSION_MIN)
-elif PYSIDE_VERSION and parse(PYSIDE_VERSION) < parse(PYSIDE_VERSION_MIN):
-    _warn_old_minor_version('PySide', PYSIDE_VERSION, PYSIDE_VERSION_MIN)
+# Warn if using an End of Life or unsupported Qt API/binding minor version
+if QT_VERSION:
+    if parse(QT_VERSION) < parse(QT5_VERSION_MIN):
+        _warn_old_minor_version('Qt5', QT_VERSION, QT5_VERSION_MIN)
+    elif parse('6') <= parse(QT_VERSION) < parse(QT6_VERSION_MIN):
+        _warn_old_minor_version('Qt6', QT_VERSION, QT6_VERSION_MIN)
+if PYQT_VERSION:
+    if parse(PYQT_VERSION) < parse(PYQT5_VERSION_MIN):
+        _warn_old_minor_version('PyQt5', PYQT_VERSION, PYQT5_VERSION_MIN)
+    elif parse('6') <= parse(PYQT_VERSION) < parse(PYQT6_VERSION_MIN):
+        _warn_old_minor_version('PyQt6', PYQT_VERSION, PYQT6_VERSION_MIN)
+elif PYSIDE_VERSION:
+    if parse(PYSIDE_VERSION) < parse(PYSIDE2_VERSION_MIN):
+        _warn_old_minor_version('PySide2', PYSIDE_VERSION, PYSIDE2_VERSION_MIN)
+    elif parse('6') <= parse(PYSIDE_VERSION) < parse(PYSIDE6_VERSION_MIN):
+        _warn_old_minor_version('PySide6', PYSIDE_VERSION, PYSIDE6_VERSION_MIN)


### PR DESCRIPTION
Per the discussion in #233 , adds a minimum version check for Qt6 and each binding to ensure they are at least version 6.2.0 or higher, since we don't officially support anything under that. Also, refactors the constants a bit accordingly.

Closes #233 (again)