### PR TITLE
PR: Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.9']
+        python-version: ['3.7', '3.9']
         use-conda: ['Yes', 'No']
         include:
         - os: ubuntu-latest
           special-invocation: 'xvfb-run --auto-servernum '
-        - python-version: '3.6'
+        - python-version: '3.7'
           use-conda: 'No'
-          skip-pip-check: 'true'  # Pytest packaging issue on Python 3.6 defaults channel
+          skip-pip-check: 'true'  # Pytest packaging issue on Python 3.7 defaults channel
           pyside2-version: 5.12.0  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
         - os: ubuntu-latest
-          python-version: '3.6'
+          python-version: '3.7'
           use-conda: 'No'
           skip-pyqt6: true  # No wheels on Py 3.6 Linux CIs
         - os: windows-latest
@@ -55,13 +55,14 @@ jobs:
           use-conda: 'No'
           pyside2-version: 5.15  # No 5.12 wheel on Windows and Python 3.9
         - os: windows-latest
-          python-version: '3.6'
-          use-conda: 'Yes'
-          pyqt5-qt-version: '5.9'  # 5.12 is apparently unreliable here
-        - os: macos-latest
-          python-version: '3.6'
+          python-version: '3.7'
           use-conda: 'No'
-          skip-pyqt6: true  # No wheels on Py 3.6 macOS CIs
+          skip-pip-check: 'true'  # Pytest packaging issue on Python 3.7 defaults channel
+        - os: macos-latest
+          python-version: '3.7'
+          use-conda: 'No'
+          skip-pyqt6: true  # No wheels on Py 3.7 macOS CIs
+          skip-pip-check: 'true'  # Pytest packaging issue on Python 3.7 defaults channel
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = QtPy
 version = attr: qtpy.__version__
-description = Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6) and additional custom QWidgets.
+description = Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6)
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/spyder-ide/qtpy
@@ -24,10 +24,10 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: User Interfaces
     Topic :: Software Development :: Widget Sets
@@ -41,7 +41,7 @@ project_urls =
 packages = find:
 install_requires =
     packaging
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
That's because that version is about to reach end-of-life.