### PR TITLE
PR: Add support for Python 3.10 on CIs and packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.9']
+        python-version: ['3.6', '3.10']
         use-conda: ['Yes', 'No']
         include:
         - os: ubuntu-latest
-          special-invocation: 'xvfb-run --auto-servernum '
+          special-invocation: 'xvfb-run --auto-servernum '  # Needed for GUI tests to work
+        - python-version: '3.10'
+          skip-pyside2: true  # Skip Pyside2 on all Python 3.10 builds until it supports it
+        - use-conda: 'Yes'  # No conda packages yet for Qt6
+          skip-pyqt6: true
+          skip-pyside6: true
         - python-version: '3.6'
           use-conda: 'No'
           skip-pip-check: 'true'  # Pytest packaging issue on Python 3.6 defaults channel
-          pyside2-version: 5.12.0  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
-        - os: ubuntu-latest
-          python-version: '3.6'
-          use-conda: 'No'
-          skip-pyqt6: true  # No wheels on Py 3.6 Linux CIs
+          pyside2-version: '5.12.0'  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
         - os: windows-latest
-          python-version: '3.9'
+          python-version: '3.10'
           use-conda: 'No'
-          pyside2-version: 5.15  # No 5.12 wheel on Windows and Python 3.9
+          pyside2-version: '5.15'  # No 5.12 wheel on Windows and Python 3.10
         - os: windows-latest
           python-version: '3.6'
           use-conda: 'Yes'
@@ -61,7 +62,7 @@ jobs:
         - os: macos-latest
           python-version: '3.6'
           use-conda: 'No'
-          skip-pyqt6: true  # No wheels on Py 3.6 macOS CIs
+          skip-pyside6: true  # Py3.6 wheels apparently still don't work on latest macOS
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -91,13 +92,13 @@ jobs:
         if: (! matrix.skip-pyqt5)
         run: ./.github/workflows/test.sh pyqt5
       - name: Test PyQt6
-        if: always() && (! ((matrix.skip-pyqt6) || (matrix.use-conda == 'Yes')))  # No conda packages yet for Qt6/PyQt6
+        if: always() && (! (matrix.skip-pyqt6))
         run: ./.github/workflows/test.sh pyqt6
       - name: Test PySide2
         if: always() && (! (matrix.skip-pyside2))
         run: ./.github/workflows/test.sh pyside2
       - name: Test PySide6
-        if: always() && (! ((matrix.skip-pyside6) || (matrix.use-conda == 'Yes')))  # No conda packages yet for Qt6/Pyside6
+        if: always() && (! (matrix.skip-pyside6))
         run: ./.github/workflows/test.sh pyside6
       - name: Upload coverage data to coveralls.io
         shell: bash

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,16 +3,11 @@
 # Activate conda properly
 eval "$(conda shell.bash hook)"
 
-# Set conda channel
-if [ "$USE_CONDA" = "No" ]; then
-    CONDA_CHANNEL_ARG="-c anaconda"
-fi
-
 # Remove any existing env
-conda remove -q -n test-env ${CONDA_CHANNEL_ARG} --all || true
+conda remove -q -n test-env --all || true
 
 # Create and activate conda environment for this test
-conda create -q -n test-env ${CONDA_CHANNEL_ARG} python=${PYTHON_VERSION} pytest pytest-cov
+conda create -q -n test-env python=${PYTHON_VERSION} pytest pytest-cov
 conda activate test-env
 
 if [ "$USE_CONDA" = "Yes" ]; then
@@ -44,10 +39,10 @@ fi
 # Build wheel of package
 git clean -xdf -e *.coverage
 python -m pip install --upgrade build
-python -bb -X dev -W error -W ignore:::pyparsing -m build
+python -bb -X dev -W error -m build
 
 # Install package from built wheel
-echo dist/*.whl | xargs -I % python -bb -X dev -W error -m pip install --upgrade %
+echo dist/*.whl | xargs -I % python -bb -X dev -W error -W "ignore::DeprecationWarning:pip._internal.locations._distutils" -W "ignore::DeprecationWarning:distutils.command.install" -m pip install --upgrade %
 
 # Print environment information
 conda list

--- a/qtpy/tests/test_uic.py
+++ b/qtpy/tests/test_uic.py
@@ -140,4 +140,4 @@ def test_load_full_uic():
     else:
         objects = ['compileUi', 'compileUiDir', 'loadUi', 'loadUiType',
                    'widgetPluginPath']
-        assert all((hasattr(uic, o) for o in objects))
+        assert all(hasattr(uic, o) for o in objects)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = QtPy
 version = attr: qtpy.__version__
-description = Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6) and additional custom QWidgets.
+description = Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6).
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/spyder-ide/qtpy
@@ -28,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: User Interfaces
     Topic :: Software Development :: Widget Sets


### PR DESCRIPTION
Adds Python 3.10 to the CIs, and official support to the packaging metadata, and takes care of a few related warnings.

Also, simplifies the CI config a bit, unskips the Linux PySide6 Py3.6 wheels since they are now available (the macOS ones now are too, but they are failing on the latest macOS), and skips PySide2 for now on Python 3.10, since it doesn't (yet) support it.

Fixes #269 