### PR TITLE
make QLibraryInfo.location works

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -28,6 +28,8 @@ if PYQT6:
     QCoreApplication.exec_ = QCoreApplication.exec
     QEventLoop.exec_ = QEventLoop.exec
     QThread.exec_ = QThread.exec
+    
+    QLibraryInfo.location = QLibraryInfo.path 
 
     # Those are imported from `import *`
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR


### PR DESCRIPTION
(found while trying to patch Pyzo for PyQt6-6.2.2)