### PR TITLE
PR: Fix QFileSystemModel for PyQt6

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -14,7 +14,7 @@ from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, PythonQtError
 if PYQT6:
     from PyQt6 import QtWidgets
     from PyQt6.QtWidgets import *
-    from PyQt6.QtGui import QAction, QActionGroup, QShortcut
+    from PyQt6.QtGui import QAction, QActionGroup, QShortcut, QFileSystemModel
     from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
     # Map missing/renamed methods


### PR DESCRIPTION
For some reason they moved it to QtGui.

FWIW, I'm doing some CI builds for Pyzo, and the one for Linux/py39/PyQt6 broke on this. After the proposed change, it worked. Also see https://stackoverflow.com/questions/66872811/is-the-icon-functionality-of-qfilesystemmodel-broken-in-pyqt6-on-windows?noredirect=1&lq=1
