### PR TITLE
PR: Set CI job's timeout to 10 min to force a stalled test to terminate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: Test ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     defaults:
       run:
         shell: ${{ matrix.special-invocation }}bash -l {0}


### PR DESCRIPTION
ref: https://github.com/spyder-ide/qtpy/pull/308#issuecomment-1000834513