### PR TITLE
PR: Add missing `QtGui` utility function to `QtCore.Qt` for PySide bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: Test ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 12
     defaults:
       run:
         shell: ${{ matrix.special-invocation }}bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: Test ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 12
+    timeout-minutes: 15
     defaults:
       run:
         shell: ${{ matrix.special-invocation }}bash -l {0}

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -7,7 +7,7 @@ eval "$(conda shell.bash hook)"
 conda remove -q -n test-env --all || true
 
 # Create and activate conda environment for this test
-conda create -q -n test-env python=${PYTHON_VERSION} pytest pytest-cov
+conda create -q -n test-env python=${PYTHON_VERSION} pytest 'pytest-cov>=3.0.0'
 conda activate test-env
 
 if [ "$USE_CONDA" = "Yes" ]; then

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -24,6 +24,15 @@ if PYQT6:
     from PyQt6.QtCore import QDateTime
     QDateTime.toPython = QDateTime.toPyDateTime
 
+    # For issue #311
+    # Seems like there is an error with sip. Without first
+    # trying to import `PyQt6.QtGui.Qt`
+    # Some functions like `PyQt6.QtCore.Qt.mightBeRichText` are missing
+    try:
+        from PyQt6.QtGui import Qt
+    except ImportError:
+        pass
+
     # Map missing methods
     QCoreApplication.exec_ = QCoreApplication.exec
     QEventLoop.exec_ = QEventLoop.exec

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -96,7 +96,11 @@ elif PYSIDE2:
 
     # Missing QtGui utility functions on Qt
     if getattr(Qt, 'mightBeRichText', None) is None:
-        from PySide2.QtGui import Qt as guiQt
-        Qt.mightBeRichText = guiQt.mightBeRichText
+        try:
+            from PySide2.QtGui import Qt as guiQt
+            Qt.mightBeRichText = guiQt.mightBeRichText
+        except ImportError:
+            # Fails with PySide2 5.12.0
+            pass
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -58,6 +58,11 @@ elif PYSIDE6:
     import PySide6.QtCore
     __version__ = PySide6.QtCore.__version__
 
+    # Missing QtGui utility functions on Qt
+    if getattr(Qt, 'mightBeRichText', None) is None:
+        from PySide6.QtGui import Qt as guiQt
+        Qt.mightBeRichText = guiQt.mightBeRichText
+
     # obsolete in qt6
     Qt.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ForegroundRole
@@ -79,5 +84,10 @@ elif PYSIDE2:
 
     import PySide2.QtCore
     __version__ = PySide2.QtCore.__version__
+
+    # Missing QtGui utility functions on Qt
+    if getattr(Qt, 'mightBeRichText', None) is None:
+        from PySide2.QtGui import Qt as guiQt
+        Qt.mightBeRichText = guiQt.mightBeRichText
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -71,6 +71,7 @@ elif PYSIDE6:
     if getattr(Qt, 'mightBeRichText', None) is None:
         from PySide6.QtGui import Qt as guiQt
         Qt.mightBeRichText = guiQt.mightBeRichText
+        del guiQt
 
     # obsolete in qt6
     Qt.BackgroundColorRole = Qt.BackgroundRole
@@ -99,6 +100,7 @@ elif PYSIDE2:
         try:
             from PySide2.QtGui import Qt as guiQt
             Qt.mightBeRichText = guiQt.mightBeRichText
+            del guiQt
         except ImportError:
             # Fails with PySide2 5.12.0
             pass

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -26,8 +26,8 @@ if PYQT6:
 
     # For issue #311
     # Seems like there is an error with sip. Without first
-    # trying to import `PyQt6.QtGui.Qt`
-    # Some functions like `PyQt6.QtCore.Qt.mightBeRichText` are missing
+    # trying to import `PyQt6.QtGui.Qt`, some functions like
+    # `PyQt6.QtCore.Qt.mightBeRichText` are missing.
     try:
         from PyQt6.QtGui import Qt
     except ImportError:

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -37,3 +37,14 @@ def test_enum_access():
     assert QtCore.Qt.Key_Return == QtCore.Qt.Key.Key_Return
     assert QtCore.Qt.transparent == QtCore.Qt.GlobalColor.transparent
     assert QtCore.Qt.Widget == QtCore.Qt.WindowType.Widget
+
+
+@pytest.mark.skipif(PYQT5 or PYQT6,
+                    reason="Unavailable by default for PyQt")
+def test_qtgui_namespace_mightBeRichText():
+    """
+    Test included elements (mightBeRichText) from module QtGui.
+
+    See: https://doc.qt.io/qt-5/qt-sub-qtgui.html
+    """
+    assert QtCore.Qt.mightBeRichText is not None

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -39,8 +39,6 @@ def test_enum_access():
     assert QtCore.Qt.Widget == QtCore.Qt.WindowType.Widget
 
 
-@pytest.mark.skipif(PYQT5 or PYQT6,
-                    reason="Unavailable by default for PyQt")
 def test_qtgui_namespace_mightBeRichText():
     """
     Test included elements (mightBeRichText) from module QtGui.

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from qtpy import PYQT5, PYQT6, PYSIDE2, PYQT_VERSION, QtCore
+from qtpy import PYQT5, PYQT6, PYSIDE2, PYQT_VERSION, PYSIDE_VERSION, QtCore
 
 
 def test_qtmsghandler():
@@ -39,6 +39,8 @@ def test_enum_access():
     assert QtCore.Qt.Widget == QtCore.Qt.WindowType.Widget
 
 
+@pytest.mark.skipif(PYSIDE2 and PYSIDE_VERSION.startswith('5.12.0'),
+                    reason="Utility functions unavailable for PySide2 5.12.0")
 def test_qtgui_namespace_mightBeRichText():
     """
     Test included elements (mightBeRichText) from module QtGui.

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,4 +55,4 @@ exclude =
 [options.extras_require]
 test =
     pytest>=6.0.0,<7.0
-    pytest-cov>=2.11.0
+    pytest-cov>=3.0.0


### PR DESCRIPTION
Fixes #311 

Edit: Also fixes an issue with PyQt6 and sip to use `mightBeRichText`:

![imagen](https://user-images.githubusercontent.com/16781833/149383160-f294e69b-9736-454e-afe0-e9fda20f182a.png)

