### PR TITLE
PR: Add mapping for missing enum values aliases on `QtCore.Qt`

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -83,9 +83,9 @@ elif PYSIDE6:
         del guiQt
 
     # Map Qt6 removed obsolete ItemDataRole enum values
-    Qt.BackgroundColorRole = Qt.BackgroundRole
-    Qt.TextColorRole = Qt.ForegroundRole
-    Qt.MidButton = Qt.MiddleButton
+    Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
+    Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
+    Qt.MidButton = Qt.MouseButton.MiddleButton = Qt.MiddleButton
 
     # Map DeprecationWarning methods
     QCoreApplication.exec_ = QCoreApplication.exec

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -47,6 +47,15 @@ if PYQT6:
     from .enums_compat import promote_enums
     promote_enums(QtCore)
     del QtCore
+
+    # Map missing unscoped access enum values
+    Qt.BackButton = Qt.XButton1
+    Qt.ForwardButton = Qt.XButton2
+
+    # Map Qt6 removed obsolete ItemDataRole enum values
+    Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
+    Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
+
 elif PYQT5:
     from PyQt5.QtCore import *
     from PyQt5.QtCore import pyqtSignal as Signal
@@ -73,7 +82,7 @@ elif PYSIDE6:
         Qt.mightBeRichText = guiQt.mightBeRichText
         del guiQt
 
-    # obsolete in qt6
+    # Map Qt6 removed obsolete ItemDataRole enum values
     Qt.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ForegroundRole
     Qt.MidButton = Qt.MiddleButton

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -52,7 +52,7 @@ if PYQT6:
     Qt.BackButton = Qt.XButton1
     Qt.ForwardButton = Qt.XButton2
 
-    # Map Qt6 removed obsolete ItemDataRole enum values
+    # Alias deprecated ItemDataRole enum values removed in Qt6
     Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
 
@@ -82,7 +82,7 @@ elif PYSIDE6:
         Qt.mightBeRichText = guiQt.mightBeRichText
         del guiQt
 
-    # Map Qt6 removed obsolete ItemDataRole enum values
+    # Alias deprecated ItemDataRole enum values removed in Qt6
     Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
     Qt.MidButton = Qt.MouseButton.MiddleButton = Qt.MiddleButton

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from qtpy import PYQT5, PYQT6, PYSIDE2, PYQT_VERSION, PYSIDE_VERSION, QtCore
+from qtpy import PYQT5, PYQT6, PYSIDE2, PYSIDE6, PYQT_VERSION, PYSIDE_VERSION, QtCore
 
 
 def test_qtmsghandler():
@@ -41,6 +41,8 @@ def test_enum_access():
     assert QtCore.Qt.XButton1 == QtCore.Qt.MouseButton.XButton1
     assert QtCore.Qt.BackgroundColorRole == QtCore.Qt.ItemDataRole.BackgroundColorRole
     assert QtCore.Qt.TextColorRole == QtCore.Qt.ItemDataRole.TextColorRole
+    if PYSIDE2 or PYSIDE6:
+        assert QtCore.Qt.MidButton == QtCore.Qt.MouseButton.MiddleButton
 
 
 @pytest.mark.skipif(PYSIDE2 and PYSIDE_VERSION.startswith('5.12.0'),

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -37,6 +37,10 @@ def test_enum_access():
     assert QtCore.Qt.Key_Return == QtCore.Qt.Key.Key_Return
     assert QtCore.Qt.transparent == QtCore.Qt.GlobalColor.transparent
     assert QtCore.Qt.Widget == QtCore.Qt.WindowType.Widget
+    assert QtCore.Qt.BackButton == QtCore.Qt.MouseButton.XButton1
+    assert QtCore.Qt.XButton1 == QtCore.Qt.MouseButton.XButton1
+    assert QtCore.Qt.BackgroundColorRole == QtCore.Qt.ItemDataRole.BackgroundColorRole
+    assert QtCore.Qt.TextColorRole == QtCore.Qt.ItemDataRole.TextColorRole
 
 
 @pytest.mark.skipif(PYSIDE2 and PYSIDE_VERSION.startswith('5.12.0'),


### PR DESCRIPTION
Fixes #306 

Note: Needs a rebase after #313 is merged