### PR TITLE
Patch QGuiApplication.desktop() for PySide6

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -33,7 +33,10 @@ elif PYSIDE2:
 elif PYSIDE6:
     from PySide6.QtGui import *
     from PySide6.QtOpenGL import *
+
+    # Map missing/renamed methods
     QFontMetrics.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
+    QGuiApplication.desktop = lambda self: self.primaryScreen()
 
     # Map DeprecationWarning methods
     QDrag.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)


### PR DESCRIPTION
`QGuiApplication.desktop()` is no longer available in PySide.

From PySide6's [_Class/Function Deprecations_][1]:

> `QDesktopWidget` has been removed. `QScreen` should be used instead, which can be retrieved using `QWidget.screen()`, `QGuiApplication.primaryScreen()` or` QGuiApplication.screens()`.

`QScreen` does not completely mimics `QDesktopWidget`, so further patching is still required.

[1]: https://doc.qt.io/qtforpython/porting_from2.html#class-function-deprecations