### PR TITLE
PR: Promote enum aliases

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -48,10 +48,6 @@ if PYQT6:
     promote_enums(QtCore)
     del QtCore
 
-    # Map missing unscoped access enum values
-    Qt.BackButton = Qt.XButton1
-    Qt.ForwardButton = Qt.XButton2
-
     # Alias deprecated ItemDataRole enum values removed in Qt6
     Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole

--- a/qtpy/enums_compat.py
+++ b/qtpy/enums_compat.py
@@ -21,7 +21,9 @@ if PYQT6:
         Search enums in the given module and allow unscoped access.
 
         Taken from:
-        https://github.com/pyqtgraph/pyqtgraph/blob/pyqtgraph-0.12.1/pyqtgraph/Qt.py#L331-L377 
+        https://github.com/pyqtgraph/pyqtgraph/blob/pyqtgraph-0.12.1/pyqtgraph/Qt.py#L331-L377
+        and adapted to also copy enum values aliased under different names.
+
         """
         class_names = [name for name in dir(module) if name.startswith('Q')]
         for class_name in class_names:
@@ -33,5 +35,5 @@ if PYQT6:
                 attrib = getattr(klass, attrib_name)
                 if not isinstance(attrib, enum.EnumMeta):
                     continue
-                for enum_obj in attrib:
-                    setattr(klass, enum_obj.name, enum_obj)
+                for name, value in attrib.__members__.items():
+                    setattr(klass, name, value)

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -37,7 +37,7 @@ def test_enum_access():
     assert QtCore.Qt.Key_Return == QtCore.Qt.Key.Key_Return
     assert QtCore.Qt.transparent == QtCore.Qt.GlobalColor.transparent
     assert QtCore.Qt.Widget == QtCore.Qt.WindowType.Widget
-    assert QtCore.Qt.BackButton == QtCore.Qt.MouseButton.XButton1
+    assert QtCore.Qt.BackButton == QtCore.Qt.MouseButton.BackButton
     assert QtCore.Qt.XButton1 == QtCore.Qt.MouseButton.XButton1
     assert QtCore.Qt.BackgroundColorRole == QtCore.Qt.ItemDataRole.BackgroundColorRole
     assert QtCore.Qt.TextColorRole == QtCore.Qt.ItemDataRole.TextColorRole

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -41,4 +41,5 @@ def test_enum_access():
     assert QtWidgets.QFileDialog.AcceptOpen == QtWidgets.QFileDialog.AcceptMode.AcceptOpen
     assert QtWidgets.QMessageBox.InvalidRole == QtWidgets.QMessageBox.ButtonRole.InvalidRole
     assert QtWidgets.QStyle.State_None == QtWidgets.QStyle.StateFlag.State_None
+    assert QtWidgets.QSlider.TicksLeft == QtWidgets.QSlider.TickPosition.TicksAbove
     assert QtWidgets.QStyle.SC_SliderGroove == QtWidgets.QStyle.SubControl.SC_SliderGroove

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -41,3 +41,4 @@ def test_enum_access():
     assert QtWidgets.QFileDialog.AcceptOpen == QtWidgets.QFileDialog.AcceptMode.AcceptOpen
     assert QtWidgets.QMessageBox.InvalidRole == QtWidgets.QMessageBox.ButtonRole.InvalidRole
     assert QtWidgets.QStyle.State_None == QtWidgets.QStyle.StateFlag.State_None
+    assert QtWidgets.QStyle.SC_SliderGroove == QtWidgets.QStyle.SubControl.SC_SliderGroove


### PR DESCRIPTION
A number of enum values in QT can be accessed through aliases. For example, QSlider.TicksPosition has both TicksAbove  and TicksLeft and TicksLeft is an alias of TicksAbove.

Currently, enums are only iterated which yield their variants but miss the existence of aliases. This patch explicitly iterate over the enum members to catch all aliases. Tests are included, both for TicksLeft which is a documented alias (https://doc.qt.io/qt-6/qslider.html#TickPosition-enum) and SC_SliderGroove which happens to have the same value as SC_ScrollBarAddLine and hence appears as an alias.