### PR TITLE
PR: Restrict broken Pytest versions to those not affected by the Pytest 7.0.0 import-mode=importlib behavior regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: Test ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     defaults:
       run:
         shell: ${{ matrix.special-invocation }}bash -l {0}

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -11,7 +11,7 @@ BINDING=$(echo "$1" | tr '[:lower:]' '[:upper:]')
 QT_VERSION_VAR=${BINDING}_QT_VERSION
 if [ "${!QT_VERSION_VAR:0:3}" = "5.9" ]; then PYTESTQT_VERSION="=3.3.0"; fi  # pytest-qt >=4 doesn't support Qt >=5.9
 if [ "${PYTHON_VERSION}" = "3.6" ]; then PIP_VERSION="=21.3.1"; fi # pip >21.3.1 depends on the 'dataclasses' module (unavailable by default with Python 3.6)
-conda create -q -n test-env python=${PYTHON_VERSION} pytest 'pytest-cov>=3.0.0' pytest-qt${PYTESTQT_VERSION:-} pip${PIP_VERSION:-}
+conda create -q -n test-env python=${PYTHON_VERSION} "pytest>=6,!=7.0.0,!=7.0.1" "pytest-cov>=3.0.0" pytest-qt${PYTESTQT_VERSION:-} pip${PIP_VERSION:-}
 conda activate test-env
 
 if [ "$USE_CONDA" = "Yes" ]; then

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
-include AUTHORS.md
-include CHANGELOG.md
-include LICENSE.txt
-include README.md
-include SECURITY.md
+include AUTHORS*
+include CHANGELOG*
+include LICENSE*
+include README*
+include SECURITY*
+include pytest.ini
 recursive-include qtpy/tests *.py *.ui

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,6 @@ exclude =
 
 [options.extras_require]
 test =
-    pytest>=6.0.0
+    pytest>=6,!=7.0.0,!=7.0.1
     pytest-cov>=3.0.0
     pytest-qt


### PR DESCRIPTION
Presently, Pytest's ``--importmode=importlib`` causes our test suite to fail at collection due to a regression introduced in Pytest 7.0.0, pytest-dev/pytest#9645 . This was fixed in pytest-dev/pytest#9681 , but hasn't yet made it into a Pytest release. Therefore, we work around it for now by disabling ``--importmode=importlib``.

Fixes #324 