### PR TITLE
PR: Monkey patch UIParser for Python 3.9 compatibility

### DIFF
--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -86,6 +86,15 @@ else:
         from PySide2.QtUiTools import QUiLoader
         try:
             from pyside2uic import compileUi
+            from pyside2uic.uiparser import UIParser
+            from xml.etree.ElementTree import Element
+            class ElemPatched(Element):
+                def getiterator(self, *args, **kwargs):
+                    return self.iter(*args, **kwargs)
+            def readResources(self, elem):
+                return self._readResources(ElemPatched(elem))
+            UIParser._readResources = UIParser.readResources
+            UIParser.readResources = readResources
         except ImportError:
             pass
 
@@ -247,6 +256,7 @@ else:
         import sys
         from io import StringIO
         from xml.etree.ElementTree import ElementTree
+        
         from . import QtWidgets
 
         # Parse the UI file

--- a/qtpy/uic.py
+++ b/qtpy/uic.py
@@ -86,6 +86,9 @@ else:
         from PySide2.QtUiTools import QUiLoader
         try:
             from pyside2uic import compileUi
+            # Patch UIParser as xml.etree.Elementree.Element.getiterator
+            # was deprecated since Python 3.2 and removed in Python 3.9
+            # https://docs.python.org/3.9/whatsnew/3.9.html#removed
             from pyside2uic.uiparser import UIParser
             from xml.etree.ElementTree import Element
             class ElemPatched(Element):


### PR DESCRIPTION
Monkey patch UIParser.readResources to make it works with Python 3.9. Without this patch, we get this error:

> Traceback (most recent call last):
  File "simple.py", line 12, in <module>
    MainWindowUI, MainWindowBase = uic.loadUiType(UI_FILE)
  File "\Miniconda3\envs\pysideads\lib\site-packages\qtpy\uic.py", line 271, in loadUiType
    compileUi(fd, code_stream, indent=0, from_imports=from_imports)
  File "\Miniconda3\envs\pysideads\lib\site-packages\pyside2uic\__init__.py", line 144, in compileUi
    winfo = ui_comp.compileUi(uifile, pyfile, from_imports)
  File "\Miniconda3\envs\pysideads\lib\site-packages\pyside2uic\Compiler\compiler.py", line 91, in compileUi
    w = self.parse(input_stream)
  File "\Miniconda3\envs\pysideads\lib\site-packages\pyside2uic\uiparser.py", line 882, in parse
    actor(elem)
  File "\Miniconda3\envs\pysideads\lib\site-packages\qtpy\uic.py", line 253, in readResources
    elem.getiterator = elem.iter
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getiterator'


> Methods getchildren() and getiterator() of classes ElementTree and Element in the ElementTree module have been removed. They were deprecated in Python 3.2. Use iter(x) or list(x) instead of x.getchildren() and x.iter() or list(x.iter()) instead of x.getiterator(). (Contributed by Serhiy Storchaka in bpo-36543.)

https://docs.python.org/3.9/whatsnew/3.9.html#removed