### PR TITLE
PR: Add missing `Qt.MidButton` on PyQt6

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -52,6 +52,8 @@ if PYQT6:
     # Alias deprecated ItemDataRole enum values removed in Qt6
     Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
+    # Alias for MiddleButton removed in PyQt6 but available in PyQt5, PySide2 and PySide6
+    Qt.MidButton = Qt.MiddleButton
 
 elif PYQT5:
     from PyQt5.QtCore import *

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -75,8 +75,7 @@ def test_enum_access():
     assert QtCore.Qt.XButton1 == QtCore.Qt.MouseButton.XButton1
     assert QtCore.Qt.BackgroundColorRole == QtCore.Qt.ItemDataRole.BackgroundColorRole
     assert QtCore.Qt.TextColorRole == QtCore.Qt.ItemDataRole.TextColorRole
-    if PYSIDE2 or PYSIDE6:
-        assert QtCore.Qt.MidButton == QtCore.Qt.MouseButton.MiddleButton
+    assert QtCore.Qt.MidButton == QtCore.Qt.MouseButton.MiddleButton
 
 
 @pytest.mark.skipif(PYSIDE2 and PYSIDE_VERSION.startswith('5.12.0'),


### PR DESCRIPTION
Fixes #327