### PR TITLE
PR: Use QFileDialog.Option to be compatiable with Qt6

### DIFF
--- a/qtpy/compat.py
+++ b/qtpy/compat.py
@@ -75,7 +75,7 @@ def getexistingdirectory(parent=None, caption='', basedir='',
 def _qfiledialog_wrapper(attr, parent=None, caption='', basedir='',
                          filters='', selectedfilter='', options=None):
     if options is None:
-        options = QFileDialog.Options(0)
+        options = QFileDialog.Option(0)
 
     func = getattr(QFileDialog, attr)
 


### PR DESCRIPTION
`QFileDialog.Options` does not exist on Qt6.

Tested with PyQt5 5.15.2 and PyQt6 6.2.3
