### PR TITLE
PR: Skip import of QOpenGLTime* on architectures where not available

### DIFF
--- a/qtpy/QtOpenGL.py
+++ b/qtpy/QtOpenGL.py
@@ -16,9 +16,14 @@ if PYQT5:
         QOpenGLFramebufferObjectFormat, QOpenGLShader, QOpenGLShaderProgram,
         QOpenGLContext, QOpenGLContextGroup, QOpenGLDebugLogger,
         QOpenGLDebugMessage, QOpenGLPixelTransferOptions, QOpenGLTexture,
-        QOpenGLTextureBlitter, QOpenGLTimeMonitor, QOpenGLTimerQuery,
+        QOpenGLTextureBlitter,
         QOpenGLVersionProfile, QOpenGLVertexArrayObject, QOpenGLWindow
     )
+    # These are not present on some architectures
+    try:
+        from PyQt5.QtGui import QOpenGLTimeMonitor, QOpenGLTimerQuery
+    except ImportError:
+        pass
 elif PYQT6:
     from PyQt6.QtOpenGL import *
     from PyQt6.QtGui import (QOpenGLContext, QOpenGLContextGroup)
@@ -32,9 +37,14 @@ elif PYSIDE2:
         QOpenGLFramebufferObjectFormat, QOpenGLShader, QOpenGLShaderProgram,
         QOpenGLContext, QOpenGLContextGroup, QOpenGLDebugLogger,
         QOpenGLDebugMessage, QOpenGLPixelTransferOptions, QOpenGLTexture,
-        QOpenGLTextureBlitter, QOpenGLTimeMonitor, QOpenGLTimerQuery,
+        QOpenGLTextureBlitter,
         QOpenGLVersionProfile, QOpenGLVertexArrayObject, QOpenGLWindow
     )
+    # These are not present on some architectures
+    try:
+        from PySide2.QtGui import QOpenGLTimeMonitor, QOpenGLTimerQuery
+    except ImportError:
+        pass
 else:
     raise PythonQtError('No Qt bindings could be found')
 

--- a/qtpy/QtOpenGL.py
+++ b/qtpy/QtOpenGL.py
@@ -19,7 +19,7 @@ if PYQT5:
         QOpenGLTextureBlitter,
         QOpenGLVersionProfile, QOpenGLVertexArrayObject, QOpenGLWindow
     )
-    # These are not present on some architectures
+    # These are not present on some architectures such as armhf
     try:
         from PyQt5.QtGui import QOpenGLTimeMonitor, QOpenGLTimerQuery
     except ImportError:
@@ -40,7 +40,7 @@ elif PYSIDE2:
         QOpenGLTextureBlitter,
         QOpenGLVersionProfile, QOpenGLVertexArrayObject, QOpenGLWindow
     )
-    # These are not present on some architectures
+    # These are not present on some architectures such as armhf
     try:
         from PySide2.QtGui import QOpenGLTimeMonitor, QOpenGLTimerQuery
     except ImportError:

--- a/qtpy/tests/test_qtopengl.py
+++ b/qtpy/tests/test_qtopengl.py
@@ -17,11 +17,9 @@ def test_qtopengl():
     assert QtOpenGL.QOpenGLShaderProgram is not None
     assert QtOpenGL.QOpenGLTexture is not None
     assert QtOpenGL.QOpenGLTextureBlitter is not None
-    # These are not present on some architectures
-    # assert QtOpenGL.QOpenGLTimeMonitor is not None
-    # assert QtOpenGL.QOpenGLTimerQuery is not None
     assert QtOpenGL.QOpenGLVersionProfile is not None
     assert QtOpenGL.QOpenGLVertexArrayObject is not None
     assert QtOpenGL.QOpenGLWindow is not None
-
+    # We do not test for QOpenGLTimeMonitor or QOpenGLTimerQuery as
+    # they are not present on some architectures
 

--- a/qtpy/tests/test_qtopengl.py
+++ b/qtpy/tests/test_qtopengl.py
@@ -17,8 +17,9 @@ def test_qtopengl():
     assert QtOpenGL.QOpenGLShaderProgram is not None
     assert QtOpenGL.QOpenGLTexture is not None
     assert QtOpenGL.QOpenGLTextureBlitter is not None
-    assert QtOpenGL.QOpenGLTimeMonitor is not None
-    assert QtOpenGL.QOpenGLTimerQuery is not None
+    # These are not present on some architectures
+    # assert QtOpenGL.QOpenGLTimeMonitor is not None
+    # assert QtOpenGL.QOpenGLTimerQuery is not None
     assert QtOpenGL.QOpenGLVersionProfile is not None
     assert QtOpenGL.QOpenGLVertexArrayObject is not None
     assert QtOpenGL.QOpenGLWindow is not None

--- a/qtpy/tests/test_qtopengl.py
+++ b/qtpy/tests/test_qtopengl.py
@@ -21,5 +21,5 @@ def test_qtopengl():
     assert QtOpenGL.QOpenGLVertexArrayObject is not None
     assert QtOpenGL.QOpenGLWindow is not None
     # We do not test for QOpenGLTimeMonitor or QOpenGLTimerQuery as
-    # they are not present on some architectures
+    # they are not present on some architectures such as armhf
 


### PR DESCRIPTION
`QOpenGLTimeMonitor` and `QOpenGLTimerQuery` do not exist on some architectures such as armhf; the PyQt5 and PySide2 code has a check for whether these should be included in the package. Since they are imported unconditionally, importing `qtpy.QtOpenGL` fails on those architectures.  This patch imports those two classes within a try/except block to allow for this to gracefully fail, and comments out the corresponding assertions in the test suite.