### PR TITLE
PR: Fix bug with environ handling

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -72,6 +72,10 @@ class PythonQtWarning(Warning):
     """Warning if some features are not implemented in a binding."""
 
 
+class PythonQtValueError(ValueError):
+    """Error raised if an invalid QT_API is specified."""
+
+
 # Qt API environment variable name
 QT_API = 'QT_API'
 
@@ -99,12 +103,13 @@ PYSIDE_VERSION_MIN = PYSIDE2_VERSION_MIN
 binding_specified = QT_API in os.environ
 
 API_NAMES = {'pyqt5': 'PyQt5', 'pyqt6': 'PyQt6',
-             'pyside2':'PySide2', 'pyside6': 'PySide6'}
+             'pyside2': 'PySide2', 'pyside6': 'PySide6'}
 API = os.environ.get(QT_API, 'pyqt5').lower()
 initial_api = API
 if API not in API_NAMES:
-    raise ValueError(
-        f'Specified QT_API={repr(QT_API)} not in valid options: {API_NAMES}')
+    raise PythonQtValueError(
+        f'Specified QT_API={repr(QT_API.lower())} not in valid options: '
+        f'{API_NAMES}')
 
 is_old_pyqt = is_pyqt46 = False
 QT5 = PYQT5 = True

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -98,14 +98,13 @@ PYSIDE_VERSION_MIN = PYSIDE2_VERSION_MIN
 # Detecting if a binding was specified by the user
 binding_specified = QT_API in os.environ
 
-# Setting a default value for QT_API
-os.environ.setdefault(QT_API, 'pyqt5')
-
 API_NAMES = {'pyqt5': 'PyQt5', 'pyqt6': 'PyQt6',
              'pyside2':'PySide2', 'pyside6': 'PySide6'}
-API = os.environ[QT_API].lower()
+API = os.environ.get(QT_API, 'pyqt5').lower()
 initial_api = API
-assert API in API_NAMES
+if API not in API_NAMES:
+    raise ValueError(
+        f'Specified QT_API={repr(QT_API)} not in valid options: {API_NAMES}')
 
 is_old_pyqt = is_pyqt46 = False
 QT5 = PYQT5 = True
@@ -150,7 +149,9 @@ if API in PYQT5_API:
 
             del macos_version
     except ImportError:
-        API = os.environ['QT_API'] = 'pyqt6'
+        API = 'pyqt6'
+    else:
+        os.environ['QT_API'] = API
 
 if API in PYQT6_API:
     try:
@@ -161,7 +162,9 @@ if API in PYQT6_API:
         QT6 = PYQT6 = True
 
     except ImportError:
-        API = os.environ['QT_API'] = 'pyside2'
+        API = 'pyside2'
+    else:
+        os.environ['QT_API'] = API
 
 
 if API in PYSIDE2_API:
@@ -183,7 +186,9 @@ if API in PYSIDE2_API:
 
             del macos_version
     except ImportError:
-        API = os.environ['QT_API'] = 'pyside6'
+        API = 'pyside6'
+    else:
+        os.environ['QT_API'] = API
 
 if API in PYSIDE6_API:
     try:
@@ -194,7 +199,9 @@ if API in PYSIDE6_API:
         QT6 = PYSIDE6 = True
 
     except ImportError:
-        API = os.environ['QT_API'] = 'pyqt5'
+        API = 'pyqt5'
+    else:
+        os.environ['QT_API'] = API
 
 
 # If a correct API name is passed to QT_API and it could not be found,

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -156,7 +156,7 @@ if API in PYQT5_API:
     except ImportError:
         API = 'pyqt6'
     else:
-        os.environ['QT_API'] = API
+        os.environ[QT_API] = API
 
 if API in PYQT6_API:
     try:
@@ -169,7 +169,7 @@ if API in PYQT6_API:
     except ImportError:
         API = 'pyside2'
     else:
-        os.environ['QT_API'] = API
+        os.environ[QT_API] = API
 
 
 if API in PYSIDE2_API:
@@ -193,7 +193,7 @@ if API in PYSIDE2_API:
     except ImportError:
         API = 'pyside6'
     else:
-        os.environ['QT_API'] = API
+        os.environ[QT_API] = API
 
 if API in PYSIDE6_API:
     try:
@@ -206,7 +206,7 @@ if API in PYSIDE6_API:
     except ImportError:
         API = 'pyqt5'
     else:
-        os.environ['QT_API'] = API
+        os.environ[QT_API] = API
 
 
 # If a correct API name is passed to QT_API and it could not be found,

--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -108,7 +108,7 @@ API = os.environ.get(QT_API, 'pyqt5').lower()
 initial_api = API
 if API not in API_NAMES:
     raise PythonQtValueError(
-        f'Specified QT_API={repr(QT_API.lower())} not in valid options: '
+        f'Specified QT_API={repr(QT_API.lower())} is not in valid options: '
         f'{API_NAMES}')
 
 is_old_pyqt = is_pyqt46 = False

--- a/qtpy/tests/conftest.py
+++ b/qtpy/tests/conftest.py
@@ -21,8 +21,9 @@ def pytest_report_header(config):
     versions += 'PyQt6: '
 
     try:
-        from PyQt6 import Qt
-        versions += f"PyQt: {Qt.PYQT_VERSION_STR} - Qt: {Qt.QT_VERSION_STR}"
+        from PyQt6 import QtCore
+        versions += \
+            f"PyQt: {QtCore.PYQT_VERSION_STR} - Qt: {QtCore.QT_VERSION_STR}"
     except ImportError:
         versions += 'not installed'
     except AttributeError:

--- a/qtpy/tests/test_main.py
+++ b/qtpy/tests/test_main.py
@@ -20,7 +20,7 @@ def assert_pyside2():
     assert QtGui.QPainter is PySide2.QtGui.QPainter
     assert QtWidgets.QWidget is PySide2.QtWidgets.QWidget
     assert QtWebEngineWidgets.QWebEnginePage is PySide2.QtWebEngineWidgets.QWebEnginePage
-    assert os.environ['QT_API'] == 'PySide2'
+    assert os.environ['QT_API'] == 'pyside2'
 
 def assert_pyside6():
     """
@@ -32,7 +32,7 @@ def assert_pyside6():
     assert QtWidgets.QWidget is PySide6.QtWidgets.QWidget
     # Only valid for qt>=6.2
     # assert QtWebEngineWidgets.QWebEnginePage is PySide6.QtWebEngineCore.QWebEnginePage
-    assert os.environ['QT_API'] == 'PySide6'
+    assert os.environ['QT_API'] == 'pyside6'
 
 def assert_pyqt5():
     """
@@ -46,7 +46,7 @@ def assert_pyqt5():
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebEngineWidgets.QWebEnginePage
     else:
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
-    assert os.environ['QT_API'] == 'PyQt5'
+    assert os.environ['QT_API'] == 'pyqt5'
 
 def assert_pyqt6():
     """
@@ -56,6 +56,7 @@ def assert_pyqt6():
     assert QtCore.QEvent is PyQt6.QtCore.QEvent
     assert QtGui.QPainter is PyQt6.QtGui.QPainter
     assert QtWidgets.QWidget is PyQt6.QtWidgets.QWidget
+    assert os.environ['QT_API'] == 'pyqt6'
 
 
 def test_qt_api():

--- a/qtpy/tests/test_main.py
+++ b/qtpy/tests/test_main.py
@@ -1,6 +1,10 @@
 import os
+import sys
+import subprocess
 
-from qtpy import QtCore, QtGui, QtWidgets
+import pytest
+
+from qtpy import QtCore, QtGui, QtWidgets, API_NAMES, PythonQtValueError
 try:
     # removed in qt 6.0
     from qtpy import QtWebEngineWidgets
@@ -16,6 +20,7 @@ def assert_pyside2():
     assert QtGui.QPainter is PySide2.QtGui.QPainter
     assert QtWidgets.QWidget is PySide2.QtWidgets.QWidget
     assert QtWebEngineWidgets.QWebEnginePage is PySide2.QtWebEngineWidgets.QWebEnginePage
+    assert os.environ['QT_API'] == 'PySide2'
 
 def assert_pyside6():
     """
@@ -27,6 +32,7 @@ def assert_pyside6():
     assert QtWidgets.QWidget is PySide6.QtWidgets.QWidget
     # Only valid for qt>=6.2
     # assert QtWebEngineWidgets.QWebEnginePage is PySide6.QtWebEngineCore.QWebEnginePage
+    assert os.environ['QT_API'] == 'PySide6'
 
 def assert_pyqt5():
     """
@@ -40,6 +46,7 @@ def assert_pyqt5():
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebEngineWidgets.QWebEnginePage
     else:
         assert QtWebEngineWidgets.QWebEnginePage is PyQt5.QtWebKitWidgets.QWebPage
+    assert os.environ['QT_API'] == 'PyQt5'
 
 def assert_pyqt6():
     """
@@ -83,3 +90,39 @@ def test_qt_api():
                 assert_pyqt6()
         else:
             assert_pyqt5()
+
+
+@pytest.mark.parametrize('api', API_NAMES.values())
+def test_qt_api_environ(api):
+    """
+    If no QT_API is specified but some Qt is imported, ensure environ is set properly
+    """
+    mod = f'{api}.QtCore'
+    pytest.importorskip(mod, reason=f'Requires {api}')
+    # clean env
+    env = os.environ.copy()
+    for key in ('QT_API', 'USE_QT_API'):
+        if key in env:
+            del env[key]
+    cmd = f"""
+import {mod}
+from qtpy import API
+import os
+print(API)
+print(os.environ['QT_API'])
+"""
+    output = subprocess.check_output([sys.executable, '-c', cmd], env=env)
+    got_api, env_qt_api = output.strip().decode('utf-8').splitlines()
+    assert got_api == api.lower()
+    assert env_qt_api == api.lower()
+    # Also ensure we raise a nice error
+    env['QT_API'] = 'bad'
+    cmd = """
+try:
+    import qtpy
+except ValueError as exc:
+    assert 'Specified QT_API' in str(exc), str(exc)
+else:
+    raise AssertionError('QtPy imported despite bad QT_API')
+"""
+    subprocess.check_call([sys.executable, '-Oc', cmd], env=env)

--- a/qtpy/tests/test_main.py
+++ b/qtpy/tests/test_main.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from qtpy import QtCore, QtGui, QtWidgets, API_NAMES, PythonQtValueError
+
 try:
     # removed in qt 6.0
     from qtpy import QtWebEngineWidgets
@@ -96,7 +97,7 @@ def test_qt_api():
 @pytest.mark.parametrize('api', API_NAMES.values())
 def test_qt_api_environ(api):
     """
-    If no QT_API is specified but some Qt is imported, ensure environ is set properly
+    If no QT_API is specified but some Qt is imported, ensure QT_API is set properly.
     """
     mod = f'{api}.QtCore'
     pytest.importorskip(mod, reason=f'Requires {api}')


### PR DESCRIPTION
I'm not 100% sure what the intention of modifying `os.environ` at all is, but assuming it's meant to set it so that e.g. new processes that spawn make use of the same framework, then there's a bug in the current implementation in `master`:
```
>>> import os
>>> import PyQt6
>>> 'QT_API' in os.environ
False
>>> import qtpy
>>> qtpy.API  # good
'pyqt6'
>>> 'QT_API' in os.environ  # okay...
True
>>> os.environ['QT_API']  # bad
'pyqt5'
```
This bug was found precisely because a pattern like this: have no QT_API set, import PyQt6, then import qtpy, then spawn a new process (using joblib), have it fail because in that process `import qtpy` fails because PyQt5 isn't installed, but `os.environ['QT_API'] == 'pyqt5'`.

This PR thus avoids changing `os.environ` at all until a suitable API has been chosen, and only then (in the `else` clause of the `try`s) set `os.environ[QT_API]`.

An alternative would be not to modify `os.environ` at all, but this seems less than ideal because it will make it so that the spawned process will not necessarily end up with the same Qt binding, depending on whether or not that process does an `import PyQt6` and `import qtpy` in the same order as the main process, at least in the case where a user has two bindings (e.g., PyQt5 and PyQt6).

This PR also promotes a `assert ` statement to a proper and more informative `raise ValueError(...)` (that also will not be skipped in Python optimized mode), and changes some `'QT_API'`s to `QT_API`, as it seems like that's what the variable name is for. But if either of these is not actually desirable, I can revert!

