### PR TITLE
PR: Add workaround for `mode` argument in QTextCursor.movePosition (PySide6)

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -33,33 +33,6 @@ elif PYSIDE2:
     if hasattr(QFontMetrics, 'horizontalAdvance'):
         # Needed to prevent raising a DeprecationWarning when using QFontMetrics.width
         QFontMetrics.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
-
-    # PySide2 does not accept the `mode` keyword argument in
-    # QTextCursor.movePosition() even though it is a valid optional argument
-    # as per C++ API. Fix this by monkeypatching.
-    #
-    # Notes:
-    #
-    # * The `mode` argument is called `arg__2` in PySide2 as per
-    #   QTextCursor.movePosition.__doc__ and __signature__. Using `arg__2` as
-    #   keyword argument works as intended, so does using a positional
-    #   argument. Tested with PySide2 5.15.0, 5.15.2.1 and 5.15.3; older
-    #   version, down to PySide 1, are probably affected as well [1].
-    #
-    # * PySide2 5.15.0 and 5.15.2.1 silently ignore invalid keyword arguments,
-    #   i.e. passing the `mode` keyword argument has no effect and doesn’t
-    #   raise an exception. Older versions, down to PySide 1, are probably
-    #   affected as well [1]. PySide2 5.15.3 raises an exception when `mode`or
-    #   any other invalid keyword argument is passed.
-    movePosition = QTextCursor.movePosition
-    def movePositionPatched(
-        self,
-        operation: QTextCursor.MoveOperation,
-        mode: QTextCursor.MoveMode = QTextCursor.MoveAnchor,
-        n: int = 1,
-    ) -> bool:
-        return movePosition(self, operation, mode, n)
-    QTextCursor.movePosition = movePositionPatched
 elif PYSIDE6:
     from PySide6.QtGui import *
     from PySide6.QtOpenGL import *
@@ -70,3 +43,34 @@ elif PYSIDE6:
     QGuiApplication.exec_ = QGuiApplication.exec
 else:
     raise PythonQtError('No Qt bindings could be found')
+
+if PYSIDE2 or PYSIDE6:
+    # PySide{2,6} do not accept the `mode` keyword argument in
+    # QTextCursor.movePosition() even though it is a valid optional argument
+    # as per C++ API. Fix this by monkeypatching.
+    #
+    # Notes:
+    #
+    # * The `mode` argument is called `arg__2` in PySide{2,6} as per
+    #   QTextCursor.movePosition.__doc__ and __signature__. Using `arg__2` as
+    #   keyword argument works as intended, so does using a positional
+    #   argument. Tested with PySide2 5.15.0, 5.15.2.1 and 5.15.3 and PySide6
+    #   6.3.0; older version, down to PySide 1, are probably affected as well [1].
+    #
+    # * PySide2 5.15.0 and 5.15.2.1 silently ignore invalid keyword arguments,
+    #   i.e. passing the `mode` keyword argument has no effect and doesn’t
+    #   raise an exception. Older versions, down to PySide 1, are probably
+    #   affected as well [1]. At least PySide2 5.15.3 and PySide6 6.3.0 raise an
+    #   exception when `mode` or any other invalid keyword argument is passed.
+    #
+    # [1] https://bugreports.qt.io/browse/PYSIDE-185
+    movePosition = QTextCursor.movePosition
+    def movePositionPatched(
+        self,
+        operation: QTextCursor.MoveOperation,
+        mode: QTextCursor.MoveMode = QTextCursor.MoveAnchor,
+        n: int = 1,
+    ) -> bool:
+        return movePosition(self, operation, mode, n)
+    QTextCursor.movePosition = movePositionPatched
+

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from qtpy import PYQT5, PYQT_VERSION, PYSIDE2, QtGui
+from qtpy import PYQT5, PYQT_VERSION, PYSIDE2, PYSIDE6, QtGui
 from qtpy.tests.utils import not_using_conda
 
 
@@ -57,7 +57,7 @@ def test_enum_access():
     assert QtGui.QIcon.Normal == QtGui.QIcon.Mode.Normal
     assert QtGui.QImage.Format_Invalid == QtGui.QImage.Format.Format_Invalid
 
-@pytest.mark.skipif(not PYSIDE2, reason="PySide2 specific test")
+@pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")
 def test_qtextcursor_moveposition():
     """Test monkeypatched QTextCursor.movePosition"""
     doc = QtGui.QTextDocument("foo bar baz")


### PR DESCRIPTION
Also see PR #341 