### PR TITLE
PR: Restore `WEBENGINE` constant in `QtWebEngineWidgets`

### DIFF
--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -17,6 +17,13 @@ from . import (
     QtModuleNotInstalledError,
 )
 
+
+# To test if we are using WebEngine or WebKit
+# NOTE: This constant is imported by other projects (e.g. Spyder), so please
+# don't remove it.
+WEBENGINE = True
+
+
 if PYQT5:
     try:
         from PyQt5.QtWebEngineWidgets import QWebEnginePage


### PR DESCRIPTION
This constant was removed in PR #344, but it's used by external projects (e.g. Spyder). So, they would break if they can find it.