### PR TITLE
PR: Add wrapper around sip/shiboken isdeleted/isvalid (compat.py)

### DIFF
--- a/qtpy/compat.py
+++ b/qtpy/compat.py
@@ -7,6 +7,14 @@ Compatibility functions
 """
 import sys
 
+from . import (
+    PYQT5,
+    PYQT6,
+    PYSIDE2,
+    PYSIDE6,
+    QtBindingsNotFoundError,
+)
+
 from .QtWidgets import QFileDialog
 
 
@@ -129,3 +137,16 @@ def getsavefilename(parent=None, caption='', basedir='', filters='',
                                 caption=caption, basedir=basedir,
                                 filters=filters, selectedfilter=selectedfilter,
                                 options=options)
+
+# =============================================================================
+def isalive(object):
+    """Wrapper around sip.isdeleted and shiboken.isValid which tests whether
+    an object is currently alive."""
+    if PYQT5 or PYQT6:
+        from . import sip
+        return not sip.isdeleted(object)
+    elif PYSIDE2 or PYSIDE6:
+        from . import shiboken
+        return shiboken.isValid(object)
+    else:
+        raise QtBindingsNotFoundError()

--- a/qtpy/tests/test_compat.py
+++ b/qtpy/tests/test_compat.py
@@ -1,0 +1,21 @@
+"""Test the compat module."""
+import pytest
+import sys
+
+from qtpy import compat, QtWidgets
+from qtpy.tests.utils import not_using_conda
+
+@pytest.mark.skipif(
+    ((sys.version_info.major == 3 and sys.version_info.minor == 7)
+    and sys.platform.startswith('win') and not not_using_conda()) 
+    or
+    (sys.platform.startswith('linux') and not_using_conda()),
+    reason="sip not included in Python3.7 on Windows, or in non-conda test suite on Linux"
+)
+def test_isalive(qtbot):
+    """Test compat.isalive"""
+    test_widget = QtWidgets.QWidget()
+    assert compat.isalive(test_widget) == True
+    with qtbot.waitSignal(test_widget.destroyed):
+        test_widget.deleteLater()
+    assert compat.isalive(test_widget) == False


### PR DESCRIPTION
Fixes #302 

This just adds a wrapper around the sip.isdeleted and shiboken.isValid functions