### PR TITLE
CI: Ensure conda-forge channel usage when testing with conda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
            auto-activate-base: true
            auto-update-conda: true
            channels: conda-forge
+           channel-priority: strict
       - name: Print Conda info
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Seems like the env for Windows with Python 3.7 and PyQt 5.9 on the CI is not working 