### PR TITLE
PR: Add missing `self` for `QtBindingsNotFoundError` definition

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -81,7 +81,7 @@ class QtBindingsNotFoundError(PythonQtError):
     _msg = 'No Qt bindings could be found'
     
     def __init__(self):
-        super().__init__(_msg)
+        super().__init__(self._msg)
 
 
 class QtModuleNotFoundError(ModuleNotFoundError, PythonQtError):


### PR DESCRIPTION
Part of #367 