### PR TITLE
Don't re-assign Qt.MouseButton.MiddleButton on PySide6

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -113,7 +113,7 @@ elif PYSIDE6:
     # Alias deprecated ItemDataRole enum values removed in Qt6
     Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
-    Qt.MidButton = Qt.MouseButton.MiddleButton = Qt.MiddleButton
+    Qt.MidButton = Qt.MiddleButton
 
     # Map DeprecationWarning methods
     QCoreApplication.exec_ = QCoreApplication.exec


### PR DESCRIPTION
I think this isn't needed, at least ``Qt.MouseButton.MiddleButton`` seems to exist with PySide6 6.2, 6.3, and 6.4. In 6.4 re-assigning this leads to an actual error.

Fixes https://github.com/spyder-ide/qtpy/issues/373