### PR TITLE
PR: Use raise from None when raising QtBindingsNotFoundError in __init__

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -256,7 +256,7 @@ if API in PYSIDE6_API:
         QT6 = PYSIDE6 = True
 
     except ImportError:
-        raise QtBindingsNotFoundError()
+        raise QtBindingsNotFoundError from None
     else:
         os.environ[QT_API] = API
 


### PR DESCRIPTION
As described in #390 , this fixes the `raise QtBindingsNotFoundError` in `__init__,py` to correctly use `raise ... from None`, to ensure it behaves appropriately and has a clear, understandable and non-confusing message.

Here's how the error output looked previously:

```python
>>> import qtpy.QtCore
Traceback (most recent call last):
  File "C:\Users\C. A. M. Gerlach\Documents\dev\SpyderDev\qtpy\qtpy\__init__.py", line 252, in <module>
    from PySide6 import __version__ as PYSIDE_VERSION  # analysis:ignore
ModuleNotFoundError: No module named 'PySide6'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\C. A. M. Gerlach\Documents\dev\SpyderDev\qtpy\qtpy\__init__.py", line 259, in <module>
    raise QtBindingsNotFoundError()
qtpy.QtBindingsNotFoundError: No Qt bindings could be found
```

and here's how it looks now:

```python
>>> import qtpy.QtCore
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\C. A. M. Gerlach\Documents\dev\SpyderDev\qtpy\qtpy\__init__.py", line 259, in <module>
    raise QtBindingsNotFoundError from None
qtpy.QtBindingsNotFoundError: No Qt bindings could be found
```

Fixes #390