### PR TITLE
PR: Fix `LibraryLocation` -> `LibraryPath` renaming due to deprecation with Qt6

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -63,6 +63,7 @@ elif PYQT6:
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 
     QLibraryInfo.location = QLibraryInfo.path
+    QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath
 
     # Those are imported from `import *`
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
@@ -121,3 +122,4 @@ elif PYSIDE6:
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QLibraryInfo.location = QLibraryInfo.path
+    QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -68,6 +68,11 @@ def test_qlibraryinfo_location():
     assert QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.PrefixPath) is not None
 
 
+def test_qlibraryinfo_library_location():
+    """Test QLibraryInfo.LibraryLocation"""
+    assert QtCore.QLibraryInfo.LibraryLocation is not None
+
+
 def test_qtextstreammanipulator_exec_():
     """Test QTextStreamManipulator.exec_"""
     QtCore.QTextStreamManipulator.exec_ is not None


### PR DESCRIPTION
That was a minor omission.