### PR TITLE
Remove PySide2 from APIs on Python 3.11+

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -157,6 +157,8 @@ binding_specified = QT_API in os.environ
 
 API_NAMES = {'pyqt5': 'PyQt5', 'pyside2': 'PySide2',
              'pyqt6': 'PyQt6', 'pyside6': 'PySide6'}
+if sys.version_info >= (3, 11):
+    API_NAMES.pop('pyside2')  # PySide2 does not support Python 3.11 and newer
 API = os.environ.get(QT_API, 'pyqt5').lower()
 initial_api = API
 if API not in API_NAMES:

--- a/qtpy/tests/test_cli.py
+++ b/qtpy/tests/test_cli.py
@@ -44,34 +44,37 @@ def test_cli_mypy_args():
     )
 
     if qtpy.PYQT5:
-        expected = ' '.join([
+        expected = [
             '--always-true=PYQT5',
             '--always-false=PYSIDE2',
             '--always-false=PYQT6',
             '--always-false=PYSIDE6',
-        ])
+        ]
     elif qtpy.PYSIDE2:
-        expected = ' '.join([
+        expected = [
             '--always-false=PYQT5',
             '--always-true=PYSIDE2',
             '--always-false=PYQT6',
             '--always-false=PYSIDE6',
-        ])
+        ]
     elif qtpy.PYQT6:
-        expected = ' '.join([
+        expected = [
             '--always-false=PYQT5',
             '--always-false=PYSIDE2',
             '--always-true=PYQT6',
             '--always-false=PYSIDE6',
-        ])
+        ]
     elif qtpy.PYSIDE6:
-        expected = ' '.join([
+        expected = [
             '--always-false=PYQT5',
             '--always-false=PYSIDE2',
             '--always-false=PYQT6',
             '--always-true=PYSIDE6',
-        ])
+        ]
     else:
         assert False, 'No valid API to test'
 
-    assert output.stdout.strip() == expected.strip()
+    if sys.version_info >= (3, 11):
+        expected.pop(1)  # no PySide2 there
+
+    assert output.stdout.strip() == ' '.join(expected).strip()


### PR DESCRIPTION
As far as I can judge from the [`PySide*` chat message](https://t.me/qtforpython/19724) by Florian Bruhin, PySide2 is not going to run on Python 3.11+. Currently, it crashes Python. To avoid further issues, I suggest removing it from the APIs for Python 3.11 and up.