### PR TITLE
Don't make `QTextStreamManipulator.exec_` on PyQt5/6

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -25,9 +25,6 @@ if PYQT5:
     QDateTime.toPython = lambda self, *args, **kwargs: self.toPyDateTime(*args, **kwargs)
     QTime.toPython = lambda self, *args, **kwargs: self.toPyTime(*args, **kwargs)
 
-    # Map missing methods on PyQt5 5.12
-    QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-
     # Those are imported from `import *`
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 
@@ -60,7 +57,6 @@ elif PYQT6:
     QCoreApplication.exec_ = QCoreApplication.exec
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 
     QLibraryInfo.location = QLibraryInfo.path
     QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -73,6 +73,8 @@ def test_qlibraryinfo_library_location():
     assert QtCore.QLibraryInfo.LibraryLocation is not None
 
 
+@pytest.mark.skipif(PYQT5 or PYQT6,
+                    reason="Doesn't seem to be present on PyQt5 and PyQt6")
 def test_qtextstreammanipulator_exec_():
     """Test QTextStreamManipulator.exec_"""
     QtCore.QTextStreamManipulator.exec_ is not None


### PR DESCRIPTION
Neither `exec` nor `exec_` is present on the `QTextStreamManipulator` class object in the PyQt5 (5.9.2 to 5.15.8, the latest to date) and PyQt6 (6.4.2, the latest to date).

See https://github.com/spyder-ide/qtpy/issues/402