### PR TITLE
PR: Add mappings for QMouseEvent methods

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -78,11 +78,6 @@ elif PYQT6:
 elif PYSIDE2:
     from PySide2.QtCore import *
 
-    try:  # may be limited to PySide-5.11a1 only
-        from PySide2.QtGui import QStringListModel
-    except Exception:
-        pass
-
     import PySide2.QtCore
     __version__ = PySide2.QtCore.__version__
 

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -73,7 +73,7 @@ if PYSIDE2 or PYSIDE6:
         return movePosition(self, operation, mode, n)
     QTextCursor.movePosition = movePositionPatched
 
-# close https://github.com/spyder-ide/qtpy/issues/394
+# Fix https://github.com/spyder-ide/qtpy/issues/394
 if PYQT6 or PYSIDE6:
     QMouseEvent.pos = lambda self: self.position().toPoint()
     QMouseEvent.x = lambda self: self.position().toPoint().x()

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -72,3 +72,12 @@ if PYSIDE2 or PYSIDE6:
     ) -> bool:
         return movePosition(self, operation, mode, n)
     QTextCursor.movePosition = movePositionPatched
+
+# close https://github.com/spyder-ide/qtpy/issues/394
+if PYQT6 or PYSIDE6:
+    QMouseEvent.pos = lambda self: self.position().toPoint()
+    QMouseEvent.x = lambda self: self.position().toPoint().x()
+    QMouseEvent.y = lambda self: self.position().toPoint().y()
+    QMouseEvent.globalPos = lambda self: self.globalPosition().toPoint()
+    QMouseEvent.globalX = lambda self: self.globalPosition().toPoint().x()
+    QMouseEvent.globalY = lambda self: self.globalPosition().toPoint().y()

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -74,6 +74,10 @@ if PYSIDE2 or PYSIDE6:
     QTextCursor.movePosition = movePositionPatched
 
 # Fix https://github.com/spyder-ide/qtpy/issues/394
+if PYQT5 or PYSIDE2:
+    from qtpy.QtCore import QPointF as __QPointF
+    QMouseEvent.position = lambda self: __QPointF(float(self.x()), float(self.y()))
+    QMouseEvent.globalPosition = lambda self: __QPointF(float(self.globalX()), float(self.globalY()))
 if PYQT6 or PYSIDE6:
     QMouseEvent.pos = lambda self: self.position().toPoint()
     QMouseEvent.x = lambda self: self.position().toPoint().x()

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -89,6 +89,7 @@ def test_QMouseEvent_pos_functions(qtbot):
             event.accept()
 
     window = Window()
+    window.setMinimumSize(320, 240)  # ensure the window is of sufficient size
     window.show()
 
     QtCore.QTimer.singleShot(100, lambda: qtbot.mouseMove(window, QtCore.QPoint(42, 6 * 9)))

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -69,8 +69,10 @@ def test_enum_access():
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")
 def test_QMouseEvent_pos_functions(qtbot):
-    """Test `QMouseEvent.pos` and related functions obsolete in Qt6,
-       test `QMouseEvent.position` and related functions missing from Qt5"""
+    """
+    Test `QMouseEvent.pos` and related functions removed in Qt 6,
+    and `QMouseEvent.position`, etc., missing from Qt 5.
+    """
 
     class Window(QtWidgets.QMainWindow):
         def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent) -> None:

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from qtpy import PYQT5, PYQT_VERSION, PYSIDE2, PYSIDE6, QtGui
+from qtpy import PYQT5, PYQT_VERSION, PYSIDE2, PYSIDE6, QtCore, QtGui, QtWidgets
 from qtpy.tests.utils import not_using_conda
 
 
@@ -62,14 +62,31 @@ def test_enum_access():
     assert QtGui.QImage.Format_Invalid == QtGui.QImage.Format.Format_Invalid
 
 
-def test_QMouseEvent_pos_functions():
+def test_QMouseEvent_pos_functions(qtbot):
     """Test `QMouseEvent.pos` and related functions obsolete in Qt6"""
-    assert QtGui.QMouseEvent.pos is not None
-    assert QtGui.QMouseEvent.x is not None
-    assert QtGui.QMouseEvent.y is not None
-    assert QtGui.QMouseEvent.globalPos is not None
-    assert QtGui.QMouseEvent.globalX is not None
-    assert QtGui.QMouseEvent.globalY is not None
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    class Window(QtWidgets.QMainWindow):
+        def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent) -> None:
+            assert event.globalPos() - event.pos() == self.mapToParent(QtCore.QPoint(0, 0))
+            assert event.pos().x() == event.x()
+            assert event.pos().y() == event.y()
+            assert event.globalPos().x() == event.globalX()
+            assert event.globalPos().y() == event.globalY()
+            assert event.position().x() == event.pos().x()
+            assert event.position().y() == event.pos().y()
+            assert event.globalPosition().x() == event.globalPos().x()
+            assert event.globalPosition().y() == event.globalPos().y()
+
+            event.accept()
+
+    window = Window()
+    window.show()
+
+    QtCore.QTimer.singleShot(100, lambda: qtbot.mouseMove(window, QtCore.QPoint(42, 6 * 9)))
+    QtCore.QTimer.singleShot(200, lambda: qtbot.mouseDClick(window, QtCore.Qt.LeftButton))
+    QtCore.QTimer.singleShot(300, lambda: window.close())
+    app.exec_()
 
 
 @pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -65,6 +65,9 @@ def test_enum_access():
 @pytest.mark.skipif(
     sys.platform.startswith('linux') and not_using_conda(),
     reason="Fatal Python error: Aborted on Linux CI when not using conda")
+@pytest.mark.skipif(
+    sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
+    reason="Stalls on macOS CI with Python 3.7")
 def test_QMouseEvent_pos_functions(qtbot):
     """Test `QMouseEvent.pos` and related functions obsolete in Qt6,
        test `QMouseEvent.position` and related functions missing from Qt5"""

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -61,6 +61,17 @@ def test_enum_access():
     assert QtGui.QIcon.Normal == QtGui.QIcon.Mode.Normal
     assert QtGui.QImage.Format_Invalid == QtGui.QImage.Format.Format_Invalid
 
+
+def test_QMouseEvent_pos_functions():
+    """Test `QMouseEvent.pos` and related functions obsolete in Qt6"""
+    assert QtGui.QMouseEvent.pos is not None
+    assert QtGui.QMouseEvent.x is not None
+    assert QtGui.QMouseEvent.y is not None
+    assert QtGui.QMouseEvent.globalPos is not None
+    assert QtGui.QMouseEvent.globalX is not None
+    assert QtGui.QMouseEvent.globalY is not None
+
+
 @pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")
 def test_qtextcursor_moveposition():
     """Test monkeypatched QTextCursor.movePosition"""

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -62,6 +62,9 @@ def test_enum_access():
     assert QtGui.QImage.Format_Invalid == QtGui.QImage.Format.Format_Invalid
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and not_using_conda(),
+    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_QMouseEvent_pos_functions(qtbot):
     """Test `QMouseEvent.pos` and related functions obsolete in Qt6,
        test `QMouseEvent.position` and related functions missing from Qt5"""

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -92,9 +92,9 @@ def test_QMouseEvent_pos_functions(qtbot):
     window.setMinimumSize(320, 240)  # ensure the window is of sufficient size
     window.show()
 
-    QtCore.QTimer.singleShot(100, lambda: qtbot.mouseMove(window, QtCore.QPoint(42, 6 * 9)))
-    QtCore.QTimer.singleShot(200, lambda: qtbot.mouseDClick(window, QtCore.Qt.LeftButton))
-    QtCore.QTimer.singleShot(300, lambda: window.close())
+    qtbot.mouseMove(window, QtCore.QPoint(42, 6 * 9))
+    qtbot.mouseDClick(window, QtCore.Qt.LeftButton)
+    QtCore.QTimer.singleShot(100, lambda: window.close())
 
 
 @pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -94,7 +94,6 @@ def test_QMouseEvent_pos_functions(qtbot):
 
     qtbot.mouseMove(window, QtCore.QPoint(42, 6 * 9))
     qtbot.mouseDClick(window, QtCore.Qt.LeftButton)
-    QtCore.QTimer.singleShot(100, lambda: window.close())
 
 
 @pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -63,8 +63,8 @@ def test_enum_access():
 
 
 def test_QMouseEvent_pos_functions(qtbot):
-    """Test `QMouseEvent.pos` and related functions obsolete in Qt6"""
-    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    """Test `QMouseEvent.pos` and related functions obsolete in Qt6,
+       test `QMouseEvent.position` and related functions missing from Qt5"""
 
     class Window(QtWidgets.QMainWindow):
         def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent) -> None:
@@ -86,7 +86,6 @@ def test_QMouseEvent_pos_functions(qtbot):
     QtCore.QTimer.singleShot(100, lambda: qtbot.mouseMove(window, QtCore.QPoint(42, 6 * 9)))
     QtCore.QTimer.singleShot(200, lambda: qtbot.mouseDClick(window, QtCore.Qt.LeftButton))
     QtCore.QTimer.singleShot(300, lambda: window.close())
-    app.exec_()
 
 
 @pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")


### PR DESCRIPTION
Added
```python
    QMouseEvent.pos = lambda self: self.position().toPoint()
    QMouseEvent.x = lambda self: self.position().toPoint().x()
    QMouseEvent.y = lambda self: self.position().toPoint().y()
    QMouseEvent.globalPos = lambda self: self.globalPosition().toPoint()
    QMouseEvent.globalX = lambda self: self.globalPosition().toPoint().x()
    QMouseEvent.globalY = lambda self: self.globalPosition().toPoint().y()
```
for PyQt6 and PySide6.

And I had to add 
```python
    QMouseEvent.position = lambda self: QPointF(float(self.x()), float(self.y()))
    QMouseEvent.globalPosition = lambda self: QPointF(float(self.globalX()), float(self.globalY()))
``` 
to PyQt5 and PySide2 to make the event test universal and (consequently, but this was not the required enhancement) bidirectional. This way, I check that the coordinates returned by the back-ported functions are equal to what the Qt**6** functions return (except for the type, but I use integer coordinates for that to work).