### PR TITLE
PR: Improve compatibility for `QtWidgets` and `QtGui` modules between Qt5 and Qt6 bindings

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -12,6 +12,9 @@ from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6
 
 if PYQT5:
     from PyQt5.QtGui import *
+    # Backport items moved to QtGui in Qt6
+    from PyQt5.QtWidgets import QAction, QActionGroup, QFileSystemModel, QShortcut, QUndoCommand
+
 elif PYQT6:
     from PyQt6 import QtGui
     from PyQt6.QtGui import *
@@ -30,12 +33,16 @@ elif PYQT6:
     del QtGui
 elif PYSIDE2:
     from PySide2.QtGui import *
+    # Backport items moved to QtGui in Qt6
+    from PySide2.QtWidgets import QAction, QActionGroup, QFileSystemModel, QShortcut, QUndoCommand
     if hasattr(QFontMetrics, 'horizontalAdvance'):
         # Needed to prevent raising a DeprecationWarning when using QFontMetrics.width
         QFontMetrics.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
 elif PYSIDE6:
     from PySide6.QtGui import *
     from PySide6.QtOpenGL import *
+    # Backport `QFileSystemModel` moved to QtGui in Qt6
+    from PySide6.QtWidgets import QFileSystemModel
     QFontMetrics.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
     QFontMetricsF.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
 

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -12,9 +12,9 @@ from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6
 
 if PYQT5:
     from PyQt5.QtGui import *
+
     # Backport items moved to QtGui in Qt6
     from PyQt5.QtWidgets import QAction, QActionGroup, QFileSystemModel, QShortcut, QUndoCommand
-
 elif PYQT6:
     from PyQt6 import QtGui
     from PyQt6.QtGui import *
@@ -33,16 +33,20 @@ elif PYQT6:
     del QtGui
 elif PYSIDE2:
     from PySide2.QtGui import *
+
     # Backport items moved to QtGui in Qt6
     from PySide2.QtWidgets import QAction, QActionGroup, QFileSystemModel, QShortcut, QUndoCommand
+
     if hasattr(QFontMetrics, 'horizontalAdvance'):
         # Needed to prevent raising a DeprecationWarning when using QFontMetrics.width
         QFontMetrics.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
 elif PYSIDE6:
     from PySide6.QtGui import *
     from PySide6.QtOpenGL import *
+
     # Backport `QFileSystemModel` moved to QtGui in Qt6
     from PySide6.QtWidgets import QFileSystemModel
+
     QFontMetrics.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
     QFontMetricsF.width = lambda self, *args, **kwargs: self.horizontalAdvance(*args, **kwargs)
 

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -39,6 +39,15 @@ def test_qguiapplication_functions():
     assert QtGui.QGuiApplication.exec_ is not None
 
 
+def test_what_moved_to_qtgui_in_qt6():
+    """Test what has been moved to QtGui in Qt6"""
+    assert QtGui.QAction is not None
+    assert QtGui.QActionGroup is not None
+    assert QtGui.QFileSystemModel is not None
+    assert QtGui.QShortcut is not None
+    assert QtGui.QUndoCommand is not None
+
+
 @pytest.mark.skipif(
     sys.platform.startswith('linux') and not_using_conda(),
     reason="Segmentation fault/Aborted on Linux CI when not using conda")

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -29,9 +29,13 @@ def test_qlineedit_functions():
     assert QtWidgets.QLineEdit.getTextMargins
 
 
-def test_qundocommand_object():
-    """Test object aliasing for QUndoCommand"""
-    assert QtWidgets.QUndoCommand
+def test_what_moved_to_qtgui_in_qt6():
+    """Test that we move back what has been moved to QtGui in Qt6"""
+    assert QtWidgets.QAction is not None
+    assert QtWidgets.QActionGroup is not None
+    assert QtWidgets.QFileSystemModel is not None
+    assert QtWidgets.QShortcut is not None
+    assert QtWidgets.QUndoCommand is not None
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Place `QAction`, `QActionGroup`, `QFileSystemModel`, `QShortcut`, and `QUndoCommand` both in `QtGui` and `QtWidgets`.

The rationale. When developing under `PySide6`, one can import `QAction` from `qtpy.QtGui`. When the code moved to `PyQt5`, it fails.

This is a part of the insanely large PR I recently proposed. This way, it would be easier to review the changes.