### PR TITLE
PR: Make `QtBindingsNotFoundError` also inherit from `ImportError`

### DIFF
--- a/qtpy/__init__.py
+++ b/qtpy/__init__.py
@@ -76,7 +76,7 @@ class PythonQtValueError(ValueError):
     """Error raised if an invalid QT_API is specified."""
 
 
-class QtBindingsNotFoundError(PythonQtError):
+class QtBindingsNotFoundError(PythonQtError, ImportError):
     """Error raised if no bindings could be selected."""
     _msg = 'No Qt bindings could be found'
 


### PR DESCRIPTION
In addition to `PythonQtError`, `QtBindingsNotFoundError` now also inherits from `ImportError`. This should be easier to catch from outside than a generic `RuntimeError`.

Fixes #412.