### PR TITLE
PR: Skip QtPositioning tests on Conda Qt >=6.4.3 where its not included

### DIFF
--- a/qtpy/tests/test_qtpositioning.py
+++ b/qtpy/tests/test_qtpositioning.py
@@ -1,7 +1,12 @@
 import pytest
-from qtpy import PYQT5, PYSIDE2
 
+from qtpy import QT6
+from qtpy.tests.utils import using_conda
 
+@pytest.mark.skipif(
+    QT6 and using_conda(),
+    reason="QPositioning bindings not included in Conda qt-main >= 6.4.3.",
+)
 def test_qtpositioning():
     """Test the qtpy.QtPositioning namespace"""
     from qtpy import QtPositioning


### PR DESCRIPTION
As discovered in PR #413 , as of the release of `qt-main` 6.4.3 on Conda-Forge (conda-forge/qt-main-feedstock#135), the Qt6 Conda jobs are failing because [QtPositioning is no longer included in `qt-main` as of 6.4.3](https://github.com/conda-forge/qt-main-feedstock/pull/135/files#diff-54cf74e113dd3f6d11e092fdb1d888ec82c69bdafbb15cfb6570c83ecad28f33), along with the other QSensors stuff for device sensors.

Therefore, I just went ahead and skipped the test on `QT6` and `conda`. It might be nice to be able to actually check the version, though for that we really should do a proper version comparison on the `QT_VERSION` (for which it would be a good idea to parse it and the other versions in `__init__` to "version_info"-style version tuples, e.g. under `QT_VERSION_INFO` and similar, which might be more generally useful to users and ourselves. However, since that would be a slightly less trivial change, I deferred that until getting your feedback on it.