### PR TITLE
PR: Symmetrize `path` and `location` of `QLibraryInfo`

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -58,9 +58,6 @@ elif PYQT6:
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 
-    QLibraryInfo.location = QLibraryInfo.path
-    QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath
-
     # Those are imported from `import *`
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 
@@ -112,5 +109,11 @@ elif PYSIDE6:
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
+
+# Mirror https://github.com/spyder-ide/qtpy/pull/393
+if PYQT5 or PYSIDE2:
+    QLibraryInfo.path = QLibraryInfo.location
+    QLibraryInfo.LibraryPath = QLibraryInfo.LibraryLocation
+if PYQT6 or PYSIDE6:
     QLibraryInfo.location = QLibraryInfo.path
     QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -67,7 +67,7 @@ def test_QLibraryInfo_location_and_path():
     assert QtCore.QLibraryInfo.location is not None
     assert QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.PrefixPath) is not None
     assert QtCore.QLibraryInfo.path is not None
-    assert QtCore.QLibraryInfo.path(QtCore.QLibraryInfo.LibraryPath.PrefixPath) is not None
+    assert QtCore.QLibraryInfo.path(QtCore.QLibraryInfo.PrefixPath) is not None
 
 
 def test_QLibraryInfo_LibraryLocation_and_LibraryPath():

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -62,15 +62,18 @@ def test_qthread_exec_():
     assert QtCore.QThread.exec_ is not None
 
 
-def test_qlibraryinfo_location():
-    """Test QLibraryInfo.location"""
+def test_QLibraryInfo_location_and_path():
+    """Test `QLibraryInfo.location` and `QLibraryInfo.path`"""
     assert QtCore.QLibraryInfo.location is not None
     assert QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.PrefixPath) is not None
+    assert QtCore.QLibraryInfo.path is not None
+    assert QtCore.QLibraryInfo.path(QtCore.QLibraryInfo.LibraryPath.PrefixPath) is not None
 
 
-def test_qlibraryinfo_library_location():
-    """Test QLibraryInfo.LibraryLocation"""
+def test_QLibraryInfo_LibraryLocation_and_LibraryPath():
+    """Test `QLibraryInfo.LibraryLocation` and `QLibraryInfo.LibraryPath`"""
     assert QtCore.QLibraryInfo.LibraryLocation is not None
+    assert QtCore.QLibraryInfo.LibraryPath is not None
 
 
 @pytest.mark.skipif(PYQT5 or PYQT6,


### PR DESCRIPTION
More and more code is initially written for Qt6 and then required to run on Qt5. There are many things introduced or renamed in Qt6. One of them is `QLibraryInfo.location` → `QLibraryInfo.path` and `QLibraryInfo.LibraryLocation` → `QLibraryInfo.LibraryPath`.

Following https://github.com/spyder-ide/qtpy/pull/393, I'd like to port `QLibraryInfo.path` and `QLibraryInfo.LibraryPath` back to Qt5. This way, all the supported flavors have `QLibraryInfo.location`, `QLibraryInfo.path`, `QLibraryInfo.LibraryLocation`, and `QLibraryInfo.LibraryPath` altogether.