### PR TITLE
PR: Symmetrize `QDateTime.toPython` and `toPyDateTime`, etc.

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -110,6 +110,16 @@ elif PYSIDE6:
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 
+# For issue #153 and updated for issue #305
+if PYQT5 or PYQT6:
+    QDate.toPython = lambda self, *args, **kwargs: self.toPyDate(*args, **kwargs)
+    QDateTime.toPython = lambda self, *args, **kwargs: self.toPyDateTime(*args, **kwargs)
+    QTime.toPython = lambda self, *args, **kwargs: self.toPyTime(*args, **kwargs)
+if PYSIDE2 or PYSIDE6:
+    QDate.toPyDate = lambda self, *args, **kwargs: self.toPython(*args, **kwargs)
+    QDateTime.toPyDateTime = lambda self, *args, **kwargs: self.toPython(*args, **kwargs)
+    QTime.toPyTime = lambda self, *args, **kwargs: self.toPython(*args, **kwargs)
+
 # Mirror https://github.com/spyder-ide/qtpy/pull/393
 if PYQT5 or PYSIDE2:
     QLibraryInfo.path = QLibraryInfo.location

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -19,12 +19,6 @@ if PYQT5:
     from PyQt5.QtCore import pyqtProperty as Property
     from PyQt5.QtCore import QT_VERSION_STR as __version__
 
-    # For issue #153 and updated for issue #305
-    from PyQt5.QtCore import QDate, QDateTime, QTime
-    QDate.toPython = lambda self, *args, **kwargs: self.toPyDate(*args, **kwargs)
-    QDateTime.toPython = lambda self, *args, **kwargs: self.toPyDateTime(*args, **kwargs)
-    QTime.toPython = lambda self, *args, **kwargs: self.toPyTime(*args, **kwargs)
-
     # Those are imported from `import *`
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 
@@ -36,12 +30,6 @@ elif PYQT6:
     from PyQt6.QtCore import pyqtSlot as Slot
     from PyQt6.QtCore import pyqtProperty as Property
     from PyQt6.QtCore import QT_VERSION_STR as __version__
-
-    # For issue #153 and updated for issue #305
-    from PyQt6.QtCore import QDate, QDateTime, QTime
-    QDate.toPython = lambda self, *args, **kwargs: self.toPyDate(*args, **kwargs)
-    QDateTime.toPython = lambda self, *args, **kwargs: self.toPyDateTime(*args, **kwargs)
-    QTime.toPython = lambda self, *args, **kwargs: self.toPyTime(*args, **kwargs)
 
     # For issue #311
     # Seems like there is an error with sip. Without first

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -1,7 +1,7 @@
 """Test QtCore."""
 
-from datetime import date, datetime, time
 import sys
+from datetime import datetime
 
 import pytest
 
@@ -16,34 +16,41 @@ from qtpy import (
 )
 from qtpy.tests.utils import not_using_conda
 
+NOW = datetime.now()
+# Make integer milliseconds; `floor` here, don't `round`!
+NOW = NOW.replace(microsecond=(NOW.microsecond // 1000 * 1000))
+
 
 def test_qtmsghandler():
     """Test qtpy.QtMsgHandler"""
     assert QtCore.qInstallMessageHandler is not None
 
 
-def test_qdatetime_toPython():
-    """Test QDateTime.toPython"""
-    q_date = QtCore.QDateTime.currentDateTime()
-    assert QtCore.QDateTime.toPython is not None
+def test_QDateTime_toPython_and_toPyDateTime():
+    """Test `QDateTime.toPython` and `QDateTime.toPyDateTime`"""
+    q_datetime = QtCore.QDateTime(NOW)
+    py_date = q_datetime.toPython()
+    assert py_date == NOW
+    py_date = q_datetime.toPyDateTime()
+    assert py_date == NOW
+
+
+def test_QDate_toPython_and_toPyDate():
+    """Test `QDate.toPython` and `QDate.toPyDate`"""
+    q_date = QtCore.QDateTime(NOW).date()
     py_date = q_date.toPython()
-    assert isinstance(py_date, datetime)
+    assert py_date == NOW.date()
+    py_date = q_date.toPyDate()
+    assert py_date == NOW.date()
 
 
-def test_qdate_toPython():
-    """Test QDate.toPython"""
-    q_date = QtCore.QDate.currentDate()
-    assert QtCore.QDate.toPython is not None
-    py_date = q_date.toPython()
-    assert isinstance(py_date, date)
-
-
-def test_qtime_toPython():
-    """Test QTime.toPython"""
-    q_time = QtCore.QTime.currentTime()
-    assert QtCore.QTime.toPython is not None
+def test_QTime_toPython_and_toPyTime():
+    """Test `QTime.toPython` and `QTime.toPyTime`"""
+    q_time = QtCore.QDateTime(NOW).time()
     py_time = q_time.toPython()
-    assert isinstance(py_time, time)
+    assert py_time == NOW.time()
+    py_time = q_time.toPyTime()
+    assert py_time == NOW.time()
 
 
 @pytest.mark.skipif(

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -1,7 +1,7 @@
 """Test QtCore."""
 
 import sys
-from datetime import datetime
+from datetime import date, datetime, time
 
 import pytest
 
@@ -31,6 +31,7 @@ def test_QDateTime_toPython_and_toPyDateTime(method):
     """Test `QDateTime.toPython` and `QDateTime.toPyDateTime`"""
     q_datetime = QtCore.QDateTime(NOW)
     py_datetime = getattr(q_datetime, method)()
+    assert isinstance(py_datetime, datetime)
     assert py_datetime == NOW
 
 
@@ -39,6 +40,7 @@ def test_QDate_toPython_and_toPyDate(method):
     """Test `QDate.toPython` and `QDate.toPyDate`"""
     q_date = QtCore.QDateTime(NOW).date()
     py_date = getattr(q_date, method)()
+    assert isinstance(py_date, date)
     assert py_date == NOW.date()
 
 
@@ -47,6 +49,7 @@ def test_QTime_toPython_and_toPyTime(method):
     """Test `QTime.toPython` and `QTime.toPyTime`"""
     q_time = QtCore.QDateTime(NOW).time()
     py_time = getattr(q_time, method)()
+    assert isinstance(py_time, time)
     assert py_time == NOW.time()
 
 

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -26,30 +26,27 @@ def test_qtmsghandler():
     assert QtCore.qInstallMessageHandler is not None
 
 
-def test_QDateTime_toPython_and_toPyDateTime():
+@pytest.mark.parametrize('method', ['toPython', 'toPyDateTime'])
+def test_QDateTime_toPython_and_toPyDateTime(method):
     """Test `QDateTime.toPython` and `QDateTime.toPyDateTime`"""
     q_datetime = QtCore.QDateTime(NOW)
-    py_date = q_datetime.toPython()
-    assert py_date == NOW
-    py_date = q_datetime.toPyDateTime()
-    assert py_date == NOW
+    py_datetime = getattr(q_datetime, method)()
+    assert py_datetime == NOW
 
 
-def test_QDate_toPython_and_toPyDate():
+@pytest.mark.parametrize('method', ['toPython', 'toPyDate'])
+def test_QDate_toPython_and_toPyDate(method):
     """Test `QDate.toPython` and `QDate.toPyDate`"""
     q_date = QtCore.QDateTime(NOW).date()
-    py_date = q_date.toPython()
-    assert py_date == NOW.date()
-    py_date = q_date.toPyDate()
+    py_date = getattr(q_date, method)()
     assert py_date == NOW.date()
 
 
-def test_QTime_toPython_and_toPyTime():
+@pytest.mark.parametrize('method', ['toPython', 'toPyTime'])
+def test_QTime_toPython_and_toPyTime(method):
     """Test `QTime.toPython` and `QTime.toPyTime`"""
     q_time = QtCore.QDateTime(NOW).time()
-    py_time = q_time.toPython()
-    assert py_time == NOW.time()
-    py_time = q_time.toPyTime()
+    py_time = getattr(q_time, method)()
     assert py_time == NOW.time()
 
 

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -16,9 +16,9 @@ from qtpy import (
 )
 from qtpy.tests.utils import not_using_conda
 
-NOW = datetime.now()
+_now = datetime.now()
 # Make integer milliseconds; `floor` here, don't `round`!
-NOW = NOW.replace(microsecond=(NOW.microsecond // 1000 * 1000))
+NOW = _now.replace(microsecond=(_now.microsecond // 1000 * 1000))
 
 
 def test_qtmsghandler():


### PR DESCRIPTION
As far as I've noticed, the favorable Qt5 binding was PyQt5, and for Qt6 it's PySide6. They are different in many ways beside the Qt backend. One of the differences is the way to get Python date/time from the Qt one: it's `toPyDateTime`/`toPyDate`/`toPyTime` in PyQt5/6 and one `toPython` to rule them all in PySide2/6.

To ease the transfer from PyQt5 to PySide6, I propose the expansion of https://github.com/spyder-ide/qtpy/pull/169. And some tests for the results, as @CAM-Gerlach has suggested in https://github.com/spyder-ide/qtpy/pull/403#discussion_r1095370537.