### PR TITLE
PR: Use static calls of `exec_` elsewhere where needed, and test them

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -118,3 +118,8 @@ if PYQT5 or PYSIDE2:
 if PYQT6 or PYSIDE6:
     QLibraryInfo.location = QLibraryInfo.path
     QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath
+
+# Delete imported items, which are not the part of QtCore
+del TYPE_CHECKING
+del PYQT6, PYQT5, PYSIDE2, PYSIDE6
+del possibly_static_exec

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -118,8 +118,3 @@ if PYQT5 or PYSIDE2:
 if PYQT6 or PYSIDE6:
     QLibraryInfo.location = QLibraryInfo.path
     QLibraryInfo.LibraryLocation = QLibraryInfo.LibraryPath
-
-# Delete imported items, which are not the part of QtCore
-del TYPE_CHECKING
-del PYQT6, PYQT5, PYSIDE2, PYSIDE6
-del possibly_static_exec

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,7 +10,7 @@
 from typing import TYPE_CHECKING
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6
-from .utils import _possibly_static_exec
+from .utils import possibly_static_exec
 
 if PYQT5:
     from PyQt5.QtCore import *
@@ -55,7 +55,7 @@ elif PYQT6:
             pass
 
     # Map missing methods
-    QCoreApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QCoreApplication, *args, **kwargs)
+    QCoreApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QCoreApplication, *args, **kwargs)
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 
@@ -106,7 +106,7 @@ elif PYSIDE6:
     Qt.MidButton = Qt.MiddleButton
 
     # Map DeprecationWarning methods
-    QCoreApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QCoreApplication, *args, **kwargs)
+    QCoreApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QCoreApplication, *args, **kwargs)
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,6 +10,7 @@
 from typing import TYPE_CHECKING
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6
+from .utils import _possibly_static_exec
 
 if PYQT5:
     from PyQt5.QtCore import *
@@ -54,7 +55,7 @@ elif PYQT6:
             pass
 
     # Map missing methods
-    QCoreApplication.exec_ = QCoreApplication.exec
+    QCoreApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QCoreApplication, *args, **kwargs)
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 
@@ -105,7 +106,7 @@ elif PYSIDE6:
     Qt.MidButton = Qt.MiddleButton
 
     # Map DeprecationWarning methods
-    QCoreApplication.exec_ = QCoreApplication.exec
+    QCoreApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QCoreApplication, *args, **kwargs)
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -9,7 +9,7 @@
 """Provides QtGui classes and functions."""
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import getattr_missing_optional_dep
+from .utils import _possibly_static_exec, getattr_missing_optional_dep
 
 
 _missing_optional_names = {}
@@ -65,7 +65,7 @@ elif PYQT6:
 
     # Map missing/renamed methods
     QDrag.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QGuiApplication.exec_ = QGuiApplication.exec
+    QGuiApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QGuiApplication, *args, **kwargs)
     QTextDocument.print_ = lambda self, *args, **kwargs: self.print(*args, **kwargs)
 
     # Allow unscoped access for enums inside the QtGui module
@@ -105,7 +105,7 @@ elif PYSIDE6:
 
     # Map DeprecationWarning methods
     QDrag.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QGuiApplication.exec_ = QGuiApplication.exec
+    QGuiApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QGuiApplication, *args, **kwargs)
 
 if PYSIDE2 or PYSIDE6:
     # PySide{2,6} do not accept the `mode` keyword argument in

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -9,7 +9,7 @@
 """Provides QtGui classes and functions."""
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import possibly_static_exec, getattr_missing_optional_dep
+from .utils import possibly_static_exec
 
 
 _missing_optional_names = {}
@@ -32,8 +32,11 @@ _QTOPENGL_NAMES = {
     'QOpenGLWindow',
 }
 
+
 def __getattr__(name):
     """Custom getattr to chain and wrap errors due to missing optional deps."""
+    from .utils import getattr_missing_optional_dep
+
     raise getattr_missing_optional_dep(
         name, module_name=__name__, optional_names=_missing_optional_names)
 
@@ -53,8 +56,8 @@ elif PYQT6:
     try:
         from PyQt6.QtOpenGL import *
     except ImportError as error:
-        for name in _QTOPENGL_NAMES:
-            _missing_optional_names[name] = {
+        for _name in _QTOPENGL_NAMES:
+            _missing_optional_names[_name] = {
                 'name': 'PyQt6.QtOpenGL',
                 'missing_package': 'pyopengl',
                 'import_error': error,
@@ -90,8 +93,8 @@ elif PYSIDE6:
     try:
         from PySide6.QtOpenGL import *
     except ImportError as error:
-        for name in _QTOPENGL_NAMES:
-            _missing_optional_names[name] = {
+        for _name in _QTOPENGL_NAMES:
+            _missing_optional_names[_name] = {
                 'name': 'PySide6.QtOpenGL',
                 'missing_package': 'pyopengl',
                 'import_error': error,
@@ -175,3 +178,6 @@ if PYQT6 or PYSIDE6:
     QSinglePointEvent.globalX = lambda self: self.globalPosition().toPoint().x()
     QSinglePointEvent.globalY = lambda self: self.globalPosition().toPoint().y()
 
+# Delete imported items, which are not the part of QtGui
+del PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
+del possibly_static_exec

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -9,7 +9,7 @@
 """Provides QtGui classes and functions."""
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import possibly_static_exec
+from .utils import possibly_static_exec, getattr_missing_optional_dep
 
 
 _missing_optional_names = {}
@@ -32,11 +32,8 @@ _QTOPENGL_NAMES = {
     'QOpenGLWindow',
 }
 
-
 def __getattr__(name):
     """Custom getattr to chain and wrap errors due to missing optional deps."""
-    from .utils import getattr_missing_optional_dep
-
     raise getattr_missing_optional_dep(
         name, module_name=__name__, optional_names=_missing_optional_names)
 
@@ -56,8 +53,8 @@ elif PYQT6:
     try:
         from PyQt6.QtOpenGL import *
     except ImportError as error:
-        for _name in _QTOPENGL_NAMES:
-            _missing_optional_names[_name] = {
+        for name in _QTOPENGL_NAMES:
+            _missing_optional_names[name] = {
                 'name': 'PyQt6.QtOpenGL',
                 'missing_package': 'pyopengl',
                 'import_error': error,
@@ -93,8 +90,8 @@ elif PYSIDE6:
     try:
         from PySide6.QtOpenGL import *
     except ImportError as error:
-        for _name in _QTOPENGL_NAMES:
-            _missing_optional_names[_name] = {
+        for name in _QTOPENGL_NAMES:
+            _missing_optional_names[name] = {
                 'name': 'PySide6.QtOpenGL',
                 'missing_package': 'pyopengl',
                 'import_error': error,
@@ -178,6 +175,3 @@ if PYQT6 or PYSIDE6:
     QSinglePointEvent.globalX = lambda self: self.globalPosition().toPoint().x()
     QSinglePointEvent.globalY = lambda self: self.globalPosition().toPoint().y()
 
-# Delete imported items, which are not the part of QtGui
-del PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-del possibly_static_exec

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -9,7 +9,7 @@
 """Provides QtGui classes and functions."""
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import _possibly_static_exec, getattr_missing_optional_dep
+from .utils import possibly_static_exec, getattr_missing_optional_dep
 
 
 _missing_optional_names = {}
@@ -65,7 +65,7 @@ elif PYQT6:
 
     # Map missing/renamed methods
     QDrag.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QGuiApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QGuiApplication, *args, **kwargs)
+    QGuiApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QGuiApplication, *args, **kwargs)
     QTextDocument.print_ = lambda self, *args, **kwargs: self.print(*args, **kwargs)
 
     # Allow unscoped access for enums inside the QtGui module
@@ -105,7 +105,7 @@ elif PYSIDE6:
 
     # Map DeprecationWarning methods
     QDrag.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QGuiApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QGuiApplication, *args, **kwargs)
+    QGuiApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QGuiApplication, *args, **kwargs)
 
 if PYSIDE2 or PYSIDE6:
     # PySide{2,6} do not accept the `mode` keyword argument in

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -9,7 +9,7 @@
 """Provides widget classes and functions."""
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import _possibly_static_exec, getattr_missing_optional_dep
+from .utils import possibly_static_exec, getattr_missing_optional_dep
 
 
 _missing_optional_names = {}
@@ -47,9 +47,9 @@ elif PYQT6:
     QPlainTextEdit.setTabStopWidth = lambda self, *args, **kwargs: self.setTabStopDistance(*args, **kwargs)
     QPlainTextEdit.tabStopWidth = lambda self, *args, **kwargs: self.tabStopDistance(*args, **kwargs)
     QPlainTextEdit.print_ = lambda self, *args, **kwargs: self.print(*args, **kwargs)
-    QApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QApplication, *args, **kwargs)
+    QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QApplication, *args, **kwargs)
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)
+    QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)
     QLineEdit.getTextMargins = lambda self: (self.textMargins().left(), self.textMargins().top(), self.textMargins().right(), self.textMargins().bottom())
 
     # Allow unscoped access for enums inside the QtWidgets module
@@ -82,6 +82,6 @@ elif PYSIDE6:
     QLineEdit.getTextMargins = lambda self: (self.textMargins().left(), self.textMargins().top(), self.textMargins().right(), self.textMargins().bottom())
 
     # Map DeprecationWarning methods
-    QApplication.exec_ = lambda *args, **kwargs: _possibly_static_exec(QApplication, *args, **kwargs)
+    QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QApplication, *args, **kwargs)
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)
+    QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -64,3 +64,4 @@ elif PYSIDE6:
     QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)
+

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -9,7 +9,7 @@
 """Provides widget classes and functions."""
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import possibly_static_exec
+from .utils import possibly_static_exec, getattr_missing_optional_dep
 
 
 _missing_optional_names = {}
@@ -17,8 +17,6 @@ _missing_optional_names = {}
 
 def __getattr__(name):
     """Custom getattr to chain and wrap errors due to missing optional deps."""
-    from .utils import getattr_missing_optional_dep
-
     raise getattr_missing_optional_dep(
         name, module_name=__name__, optional_names=_missing_optional_names)
 
@@ -87,7 +85,3 @@ elif PYSIDE6:
     QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QApplication, *args, **kwargs)
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)
-
-# Delete imported items, which are not the part of QtWidgets
-del PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-del possibly_static_exec

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -9,7 +9,7 @@
 """Provides widget classes and functions."""
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from .utils import possibly_static_exec, getattr_missing_optional_dep
+from .utils import possibly_static_exec
 
 
 _missing_optional_names = {}
@@ -17,6 +17,8 @@ _missing_optional_names = {}
 
 def __getattr__(name):
     """Custom getattr to chain and wrap errors due to missing optional deps."""
+    from .utils import getattr_missing_optional_dep
+
     raise getattr_missing_optional_dep(
         name, module_name=__name__, optional_names=_missing_optional_names)
 
@@ -85,3 +87,7 @@ elif PYSIDE6:
     QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QApplication, *args, **kwargs)
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)
+
+# Delete imported items, which are not the part of QtWidgets
+del PYQT6, PYQT5, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
+del possibly_static_exec

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -22,7 +22,7 @@ def __getattr__(name):
 
 
 def _possibly_static_exec(cls, *args, **kwargs):
-    """ Call `self.exec` when `self` is given or a static method otherwise. """
+    """Call `self.exec` when `self` is given or a static method otherwise."""
     if isinstance(args[0], cls):
         if len(args) == 1 and not kwargs:
             # A special case to avoid the function resolving error

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -63,5 +63,5 @@ elif PYSIDE6:
     # Map DeprecationWarning methods
     QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)
+    QMenu.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -10,6 +10,18 @@
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6
 
+
+def _possibly_static_exec(cls, *args, **kwargs):
+    """ Call `self.exec` when `self` is given or a static method otherwise. """
+    if isinstance(args[0], cls):
+        if len(args) == 1 and not kwargs:
+            # A special case to avoid the function resolving error
+            return args[0].exec()
+        return args[0].exec(*args[1:], **kwargs)
+    else:
+        return cls.exec(*args, **kwargs)
+
+
 if PYQT5:
     from PyQt5.QtWidgets import *
 elif PYQT6:
@@ -27,7 +39,7 @@ elif PYQT6:
     QPlainTextEdit.print_ = lambda self, *args, **kwargs: self.print(*args, **kwargs)
     QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QMenu.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
+    QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)
     QLineEdit.getTextMargins = lambda self: (self.textMargins().left(), self.textMargins().top(), self.textMargins().right(), self.textMargins().bottom())
 
     # Allow unscoped access for enums inside the QtWidgets module
@@ -51,4 +63,4 @@ elif PYSIDE6:
     # Map DeprecationWarning methods
     QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QMenu.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
+    QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -14,11 +14,11 @@ from .utils import getattr_missing_optional_dep
 
 _missing_optional_names = {}
 
+
 def __getattr__(name):
     """Custom getattr to chain and wrap errors due to missing optional deps."""
     raise getattr_missing_optional_dep(
         name, module_name=__name__, optional_names=_missing_optional_names)
-
 
 
 def _possibly_static_exec(cls, *args, **kwargs):
@@ -95,5 +95,4 @@ elif PYSIDE6:
     # Map DeprecationWarning methods
     QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-    QMenu.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
-
+    QMenu.exec_ = lambda *args, **kwargs: _possibly_static_exec(QMenu, *args, **kwargs)

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -76,6 +76,19 @@ def test_QLibraryInfo_LibraryLocation_and_LibraryPath():
     assert QtCore.QLibraryInfo.LibraryPath is not None
 
 
+def test_QCoreApplication_exec_():
+    """Test `QtCore.QCoreApplication.exec_`"""
+    assert QtCore.QCoreApplication.exec_ is not None
+    app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtCore.QCoreApplication.instance().quit)
+    QtCore.QCoreApplication.exec_()
+    app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtCore.QCoreApplication.instance().quit)
+    app.exec_()
+
+
 @pytest.mark.skipif(PYQT5 or PYQT6,
                     reason="Doesn't seem to be present on PyQt5 and PyQt6")
 def test_qtextstreammanipulator_exec_():

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -34,9 +34,17 @@ def test_qdrag_functions(qtbot):
     drag.exec_()
 
 
-def test_qguiapplication_functions():
-    """Test functions mapping for QtGui.QGuiApplication."""
+def test_QGuiApplication_exec_():
+    """Test `QtGui.QGuiApplication._exec_`"""
     assert QtGui.QGuiApplication.exec_ is not None
+    app = QtGui.QGuiApplication.instance() or QtGui.QGuiApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtGui.QGuiApplication.instance().quit)
+    QtGui.QGuiApplication.exec_()
+    app = QtGui.QGuiApplication.instance() or QtGui.QGuiApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtGui.QGuiApplication.instance().quit)
+    app.exec_()
 
 
 def test_what_moved_to_qtgui_in_qt6():

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -34,8 +34,11 @@ def test_qdrag_functions(qtbot):
     drag.exec_()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and not_using_conda(),
+    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_QGuiApplication_exec_():
-    """Test `QtGui.QGuiApplication._exec_`"""
+    """Test `QtGui.QGuiApplication.exec_`"""
     assert QtGui.QGuiApplication.exec_ is not None
     app = QtGui.QGuiApplication.instance() or QtGui.QGuiApplication([sys.executable, __file__])
     assert app is not None

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -1,5 +1,5 @@
 """Test QtWidgets."""
-
+import contextlib
 import sys
 
 import pytest
@@ -106,7 +106,7 @@ def test_QMenu_functions(qtbot):
     menu.addAction('QtPy')
     window.show()
 
-    with qtbot.waitExposed(window):
+    with qtbot.waitExposed(window) if sys.platform == 'linux' else contextlib.nullcontext():
         # Call `exec_` of a `QMenu` instance
         QtCore.QTimer.singleShot(100, menu.close)
         menu.exec_()

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -1,5 +1,4 @@
 """Test QtWidgets."""
-import contextlib
 import sys
 
 import pytest
@@ -91,10 +90,10 @@ def test_qdialog_subclass(qtbot):
     QtCore.QTimer.singleShot(100, dialog.accept)
     dialog.exec_()
 
-
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
+#
+# @pytest.mark.skipif(
+#     sys.platform.startswith('linux') and not_using_conda(),
+#     reason="Fatal Python error: Aborted on Linux CI when not using conda")
 @pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")
@@ -106,7 +105,7 @@ def test_QMenu_functions(qtbot):
     menu.addAction('QtPy')
     window.show()
 
-    with qtbot.waitExposed(window) if sys.platform == 'linux' else contextlib.nullcontext():
+    with qtbot.waitExposed(window):
         # Call `exec_` of a `QMenu` instance
         QtCore.QTimer.singleShot(100, menu.close)
         menu.exec_()
@@ -114,7 +113,7 @@ def test_QMenu_functions(qtbot):
         # Call static `QMenu.exec_`
         QtCore.QTimer.singleShot(100, lambda: qtbot.keyClick(
             QtWidgets.QApplication.widgetAt(1, 1),
-            QtCore.Qt.Key.Key_Escape)
+            QtCore.Qt.Key_Escape)
         )
         QtWidgets.QMenu.exec_(menu.actions(), QtCore.QPoint(1, 1))
 

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -53,8 +53,11 @@ def test_qplaintextedit_functions(qtbot, pdf_writer):
     assert output_path.exists()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and not_using_conda(),
+    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_QApplication_exec_():
-    """Test `QtWidgets.QApplication._exec_`"""
+    """Test `QtWidgets.QApplication.exec_`"""
     assert QtWidgets.QApplication.exec_ is not None
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([sys.executable, __file__])
     assert app is not None

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -53,9 +53,17 @@ def test_qplaintextedit_functions(qtbot, pdf_writer):
     assert output_path.exists()
 
 
-def test_qapplication_functions():
-    """Test functions mapping for QtWidgets.QApplication."""
-    assert QtWidgets.QApplication.exec_
+def test_QApplication_exec_():
+    """Test `QtWidgets.QApplication._exec_`"""
+    assert QtWidgets.QApplication.exec_ is not None
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtWidgets.QApplication.instance().quit)
+    QtWidgets.QApplication.exec_()
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtWidgets.QApplication.instance().quit)
+    app.exec_()
 
 
 @pytest.mark.skipif(

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -90,10 +90,10 @@ def test_qdialog_subclass(qtbot):
     QtCore.QTimer.singleShot(100, dialog.accept)
     dialog.exec_()
 
-#
-# @pytest.mark.skipif(
-#     sys.platform.startswith('linux') and not_using_conda(),
-#     reason="Fatal Python error: Aborted on Linux CI when not using conda")
+
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and not_using_conda(),
+    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 @pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -98,12 +98,25 @@ def test_qdialog_subclass(qtbot):
 @pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")
-def test_qmenu_functions(qtbot):
-    """Test functions mapping for QtWidgets.QDialog."""
-    assert QtWidgets.QMenu.exec_
-    menu = QtWidgets.QMenu(None)
-    QtCore.QTimer.singleShot(100, menu.close)
-    menu.exec_()
+def test_QMenu_functions(qtbot):
+    """Test functions mapping for `QtWidgets.QMenu`."""
+    # A window is required for static calls
+    window = QtWidgets.QMainWindow()
+    menu = QtWidgets.QMenu(window)
+    menu.addAction('QtPy')
+    window.show()
+
+    with qtbot.waitExposed(window):
+        # Call `exec_` of a `QMenu` instance
+        QtCore.QTimer.singleShot(100, menu.close)
+        menu.exec_()
+
+        # Call static `QMenu.exec_`
+        QtCore.QTimer.singleShot(100, lambda: qtbot.keyClick(
+            QtWidgets.QApplication.widgetAt(1, 1),
+            QtCore.Qt.Key.Key_Escape)
+        )
+        QtWidgets.QMenu.exec_(menu.actions(), QtCore.QPoint(1, 1))
 
 
 @pytest.mark.skipif(PYQT5 and PYQT_VERSION.startswith('5.9'),

--- a/qtpy/utils.py
+++ b/qtpy/utils.py
@@ -30,3 +30,14 @@ def getattr_missing_optional_dep(name, module_name, optional_names):
     if name in optional_names:
         return _wrap_missing_optional_dep_error(attr_error, **optional_names[name])
     return attr_error
+
+
+def _possibly_static_exec(cls, *args, **kwargs):
+    """Call `self.exec` when `self` is given or a static method otherwise."""
+    if isinstance(args[0], cls):
+        if len(args) == 1 and not kwargs:
+            # A special case to avoid the function resolving error
+            return args[0].exec()
+        return args[0].exec(*args[1:], **kwargs)
+    else:
+        return cls.exec(*args, **kwargs)

--- a/qtpy/utils.py
+++ b/qtpy/utils.py
@@ -32,7 +32,7 @@ def getattr_missing_optional_dep(name, module_name, optional_names):
     return attr_error
 
 
-def _possibly_static_exec(cls, *args, **kwargs):
+def possibly_static_exec(cls, *args, **kwargs):
     """Call `self.exec` when `self` is given or a static method otherwise."""
     if not args and not kwargs:
         # A special case (`cls.exec_()`) to avoid the function resolving error

--- a/qtpy/utils.py
+++ b/qtpy/utils.py
@@ -34,9 +34,12 @@ def getattr_missing_optional_dep(name, module_name, optional_names):
 
 def _possibly_static_exec(cls, *args, **kwargs):
     """Call `self.exec` when `self` is given or a static method otherwise."""
+    if not args and not kwargs:
+        # A special case (`cls.exec_()`) to avoid the function resolving error
+        return cls.exec()
     if isinstance(args[0], cls):
         if len(args) == 1 and not kwargs:
-            # A special case to avoid the function resolving error
+            # A special case (`self.exec_()`) to avoid the function resolving error
             return args[0].exec()
         return args[0].exec(*args[1:], **kwargs)
     else:


### PR DESCRIPTION
The help for `QMenu.exec_` reads something like the following (the order might be different, and fully qualified Qt class names might appear):
```plaintext
exec_(...)
    exec_(actions: typing.Sequence[QAction], pos: QPoint, at: typing.Optional[QAction] = None, parent: typing.Optional[QWidget] = None) -> QAction
    exec_(self) -> QAction
    exec_(self, pos: QPoint, at: typing.Optional[QAction] = None) -> QAction
```
The first option here is a static call to `QMenu.exec_`. In the QtPy tests, such a call is never tested. So, here it is. As one might expect, it fails. Use the `_possibly_static_exec` function to fix the errors.