### PR TITLE
PR: Add wrapers to fix argument name in `QFileDialog` `get*`methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,6 @@ jobs:
           sudo apt update
           sudo apt install libpulse-dev libegl1-mesa libopengl0 gstreamer1.0-gl
       - uses: tlambert03/setup-qt-libs@v1
-      - name: Install Linux system packages
-        if: contains(matrix.os, 'ubuntu')
-        shell: bash
-        run: sudo apt install libpulse-dev libegl1-mesa libopengl0 gstreamer1.0-gl
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
           sudo apt update
           sudo apt install libpulse-dev libegl1-mesa libopengl0 gstreamer1.0-gl
       - uses: tlambert03/setup-qt-libs@v1
+      - name: Install Linux system packages
+        if: contains(matrix.os, 'ubuntu')
+        shell: bash
+        run: sudo apt install libpulse-dev libegl1-mesa libopengl0 gstreamer1.0-gl
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -80,7 +80,7 @@ def test_QLibraryInfo_LibraryLocation_and_LibraryPath():
     assert QtCore.QLibraryInfo.LibraryPath is not None
 
 
-def test_QCoreApplication_exec_():
+def test_QCoreApplication_exec_(qapp):
     """Test `QtCore.QCoreApplication.exec_`"""
     assert QtCore.QCoreApplication.exec_ is not None
     app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([sys.executable, __file__])

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -145,11 +145,11 @@ def test_opengl_imports():
 @pytest.mark.parametrize("instance", [True, False])
 def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
     """
-    This function is testing if the decorators that renamed keyword are
-    working.
+    This function is testing if the decorators that renamed the dir/directory
+    keyword are working.
 
-    It mas stop working if the Qt bindings do some overwriting of the methods
-    in constructor. It should not happen, but we already meet that PySide team
+    It may stop working if the Qt bindings do some overwriting of the methods
+    in constructor. It should not happen, but the PySide team
     did similar things in the past (like overwriting enum module in
     PySide6==6.3.2).
 

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -4,11 +4,11 @@ import sys
 from time import sleep
 
 import pytest
+from pytestqt.exceptions import TimeoutError
 
 from qtpy import PYQT5, PYQT_VERSION, QtCore, QtGui, QtWidgets, PYQT6, PYSIDE6, PYSIDE2
 from qtpy.tests.utils import using_conda, not_using_conda
 
-from pytestqt.exceptions import TimeoutError
 
 
 def test_qtextedit_functions(qtbot, pdf_writer):
@@ -136,29 +136,38 @@ def test_opengl_imports():
     """
     assert QtWidgets.QOpenGLWidget is not None
 
-@pytest.mark.skipif(sys.platform == 'darwin' and sys.version_info[:2] == (3, 7) and (PYQT5 or PYSIDE2), reason="test crashes on macOS CI with Python 3.7 with 'Illegal instruction: 4'")
+
+@pytest.mark.skipif(
+    sys.platform == 'darwin' and sys.version_info[:2] == (3, 7) and
+    (PYQT5 or PYSIDE2),
+    reason="Crashes on macOS with Python 3.7 with 'Illegal instruction: 4'")
 @pytest.mark.parametrize("keyword", ["dir", "directory"])
 @pytest.mark.parametrize("instance", [True, False])
 def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
     """
-    This function is testing if the decorators that renamed keyword are working.
-    It mas stop working if the Qt bindings do some overwriting of the methods in constructor. 
-    It should not happen, but we already meet that PySide team did similar things in the past 
-    (like overwriting enum module in PySide6==6.3.2).
+    This function is testing if the decorators that renamed keyword are
+    working.
+
+    It mas stop working if the Qt bindings do some overwriting of the methods
+    in constructor. It should not happen, but we already meet that PySide team
+    did similar things in the past (like overwriting enum module in
+    PySide6==6.3.2).
 
     keyword: str
         The keyword that should be used in the function call.
     instance: bool
-        If True, the function is called on the instance of the QFileDialog, otherwise on the class.
+        If True, the function is called on the instance of the QFileDialog,
+        otherwise on the class.
     """
     
     class CloseThread(QtCore.QThread):
         """
         On some implementations the `getExistingDirectory` functions starts own 
-        event loop that will not trigger QTimer started before the call. Until the
-        dialog is closed the main event loop will be stopped.
+        event loop that will not trigger QTimer started before the call. Until
+        the dialog is closed the main event loop will be stopped.
 
-        Because of this it is required to use the thread to interact with the dialog.
+        Because of this it is required to use the thread to interact with the
+        dialog.
         """
         def run(self, allow_restart=True):
             sleep(0.5)
@@ -167,10 +176,13 @@ def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
             for dlg in app.topLevelWidgets():
                 if not isinstance(dlg, QtWidgets.QFileDialog) or dlg.isHidden():
                     continue
-                # when implement this I try to use:
-                # * dlg.close() - On Qt6 it will close the dialog, but it will not restart the main event loop
-                # * dlg.accept() - It ends with information thar `accept` and `reject` of such created dialog can not be called
-                # * accept dialog with enter - It works, but it cannot be called to early after dialog is shown
+                # "when implemented this I try to use:
+                # * dlg.close() - On Qt6 it will close the dialog, but it will
+                #   not restart the main event loop.
+                # * dlg.accept() - It ends with information thar `accept` and
+                #   `reject` of such created dialog can not be called.
+                # * accept dialog with enter - It works, but it cannot be
+                #   called to early after dialog is shown
                 qtbot.keyClick(dlg, QtCore.Qt.Key_Enter)
                 need_restart = False
             sleep(0.1)
@@ -185,7 +197,8 @@ def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
             if need_restart:
                 self.run()
 
-    # we need to use the `DontUseNativeDialog` option to be able to interact with it from code. 
+    # We need to use the `DontUseNativeDialog` option to be able to interact
+    # with it from code. 
     try:
         opt = QtWidgets.QFileDialog.Option.DontUseNativeDialog
     except AttributeError:
@@ -205,4 +218,3 @@ def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
     dlg = QtWidgets.QFileDialog() if instance else QtWidgets.QFileDialog
     dlg.getExistingDirectory(**kwargs)
     qtbot.waitUntil(thr.isFinished, timeout=3000)
-    

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -1,9 +1,14 @@
 """Test QtWidgets."""
+import contextlib
 import sys
+from time import sleep
 
 import pytest
 
-from qtpy import PYQT5, PYQT_VERSION, QtCore, QtGui, QtWidgets
+from qtpy import PYQT5, PYQT_VERSION, QtCore, QtGui, QtWidgets, PYQT6, PYSIDE6, PYSIDE2
+from qtpy.tests.utils import using_conda, not_using_conda
+
+from pytestqt.exceptions import TimeoutError
 
 
 def test_qtextedit_functions(qtbot, pdf_writer):
@@ -130,3 +135,74 @@ def test_opengl_imports():
     QtPy makes QOpenGLWidget available in QtWidgets to maintain compatibility.
     """
     assert QtWidgets.QOpenGLWidget is not None
+
+@pytest.mark.skipif(sys.platform == 'darwin' and sys.version_info[:2] == (3, 7) and (PYQT5 or PYSIDE2), reason="test crashes on macOS CI with Python 3.7 with 'Illegal instruction: 4'")
+@pytest.mark.parametrize("keyword", ["dir", "directory"])
+@pytest.mark.parametrize("instance", [True, False])
+def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
+    """
+    This function is testing if the decorators that renamed keyword are working.
+    It mas stop working if the Qt bindings do some overwriting of the methods in constructor. 
+    It should not happen, but we already meet that PySide team did similar things in the past 
+    (like overwriting enum module in PySide6==6.3.2).
+
+    keyword: str
+        The keyword that should be used in the function call.
+    instance: bool
+        If True, the function is called on the instance of the QFileDialog, otherwise on the class.
+    """
+    
+    class CloseThread(QtCore.QThread):
+        """
+        On some implementations the `getExistingDirectory` functions starts own 
+        event loop that will not trigger QTimer started before the call. Until the
+        dialog is closed the main event loop will be stopped.
+
+        Because of this it is required to use the thread to interact with the dialog.
+        """
+        def run(self, allow_restart=True):
+            sleep(0.5)
+            need_restart = allow_restart
+            app = QtWidgets.QApplication.instance()
+            for dlg in app.topLevelWidgets():
+                if not isinstance(dlg, QtWidgets.QFileDialog) or dlg.isHidden():
+                    continue
+                # when implement this I try to use:
+                # * dlg.close() - On Qt6 it will close the dialog, but it will not restart the main event loop
+                # * dlg.accept() - It ends with information thar `accept` and `reject` of such created dialog can not be called
+                # * accept dialog with enter - It works, but it cannot be called to early after dialog is shown
+                qtbot.keyClick(dlg, QtCore.Qt.Key_Enter)
+                need_restart = False
+            sleep(0.1)
+            for dlg in app.topLevelWidgets():
+                # As described above, it may happen that dialog is not closed after first using enter.
+                # in such case we call `run` function again. The 0.5s sleep is enough for the second enter to close the dialog. 
+                if not isinstance(dlg, QtWidgets.QFileDialog) or dlg.isHidden():
+                    continue
+                self.run(allow_restart=False)
+                return
+
+            if need_restart:
+                self.run()
+
+    # we need to use the `DontUseNativeDialog` option to be able to interact with it from code. 
+    try:
+        opt = QtWidgets.QFileDialog.Option.DontUseNativeDialog
+    except AttributeError:
+        # old qt5 bindings
+        opt = QtWidgets.QFileDialog.DontUseNativeDialog
+    
+    kwargs = {
+        "caption": "Select a directory",
+        keyword: str(tmp_path),
+        "options": opt,
+    }
+
+
+    thr = CloseThread()
+    thr.start()
+    qtbot.waitUntil(thr.isRunning, timeout=1000)
+    dlg = QtWidgets.QFileDialog() if instance else QtWidgets.QFileDialog
+    dlg.getExistingDirectory(**kwargs)
+    qtbot.waitUntil(thr.isFinished, timeout=3000)
+    


### PR DESCRIPTION
closes #432

What did you think about this as idea? 