### PR TITLE
PR: Enable more tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
     - main
     - '*.x'
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libpulse-dev libegl1-mesa libopengl0 gstreamer1.0-gl
+      - uses: tlambert03/setup-qt-libs@v1
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/qtpy/tests/test_compat.py
+++ b/qtpy/tests/test_compat.py
@@ -7,10 +7,8 @@ from qtpy.tests.utils import not_using_conda
 
 @pytest.mark.skipif(
     ((sys.version_info.major == 3 and sys.version_info.minor == 7)
-    and sys.platform.startswith('win') and not not_using_conda()) 
-    or
-    (sys.platform.startswith('linux') and not_using_conda()),
-    reason="sip not included in Python3.7 on Windows, or in non-conda test suite on Linux"
+    and sys.platform.startswith('win') and not not_using_conda()),
+    reason="sip not included in Python3.7 on Windows"
 )
 def test_isalive(qtbot):
     """Test compat.isalive"""

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -53,9 +53,6 @@ def test_QTime_toPython_and_toPyTime(method):
     assert py_time == NOW.time()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_qeventloop_exec_(qtbot):
     """Test QEventLoop.exec_"""
     assert QtCore.QEventLoop.exec_ is not None

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -8,9 +8,6 @@ from qtpy import PYQT5, PYQT_VERSION, PYSIDE2, PYSIDE6, QtCore, QtGui, QtWidgets
 from qtpy.tests.utils import not_using_conda
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_qfontmetrics_width(qtbot):
     """Test QFontMetrics and QFontMetricsF width"""
     assert QtGui.QFontMetrics.width is not None
@@ -24,9 +21,6 @@ def test_qfontmetrics_width(qtbot):
     assert 39 <= widthF <= 63
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_qdrag_functions(qtbot):
     """Test functions mapping for QtGui.QDrag."""
     assert QtGui.QDrag.exec_ is not None
@@ -34,9 +28,6 @@ def test_qdrag_functions(qtbot):
     drag.exec_()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_QGuiApplication_exec_():
     """Test `QtGui.QGuiApplication.exec_`"""
     assert QtGui.QGuiApplication.exec_ is not None
@@ -59,9 +50,6 @@ def test_what_moved_to_qtgui_in_qt6():
     assert QtGui.QUndoCommand is not None
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Segmentation fault/Aborted on Linux CI when not using conda")
 def test_qtextdocument_functions(pdf_writer):
     """Test functions mapping for QtGui.QTextDocument."""
     assert QtGui.QTextDocument.print_ is not None
@@ -82,9 +70,6 @@ def test_enum_access():
     assert QtGui.QImage.Format_Invalid == QtGui.QImage.Format.Format_Invalid
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 @pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")

--- a/qtpy/tests/test_qtmultimedia.py
+++ b/qtpy/tests/test_qtmultimedia.py
@@ -2,13 +2,7 @@ import sys
 
 import pytest
 
-from qtpy import PYSIDE6, PYQT6
 
-
-@pytest.mark.skipif(
-    sys.platform.startswith("linux") and (PYSIDE6 or PYQT6),
-    reason="Needs to setup GStreamer on Linux",
-)
 def test_qtmultimedia():
     """Test the qtpy.QtMultimedia namespace"""
     from qtpy import QtMultimedia

--- a/qtpy/tests/test_qtmultimedia.py
+++ b/qtpy/tests/test_qtmultimedia.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+from qtpy import PYSIDE6, PYQT6
+
 
 def test_qtmultimedia():
     """Test the qtpy.QtMultimedia namespace"""

--- a/qtpy/tests/test_qtprintsupport.py
+++ b/qtpy/tests/test_qtprintsupport.py
@@ -5,7 +5,6 @@ import sys
 import pytest
 
 from qtpy import QtPrintSupport
-from qtpy.tests.utils import not_using_conda
 
 
 def test_qtprintsupport():
@@ -30,10 +29,6 @@ def test_qprintdialog_exec_():
     assert QtPrintSupport.QPrintDialog.exec_ is not None
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("linux") and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda",
-)
 def test_qprintpreviewwidget_print_(qtbot):
     """Test qtpy.QtPrintSupport.QPrintPreviewWidget print_"""
     assert QtPrintSupport.QPrintPreviewWidget.print_ is not None

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -4,12 +4,8 @@ import sys
 import pytest
 
 from qtpy import PYQT5, PYQT_VERSION, QtCore, QtGui, QtWidgets
-from qtpy.tests.utils import using_conda, not_using_conda
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_qtextedit_functions(qtbot, pdf_writer):
     """Test functions mapping for QtWidgets.QTextEdit."""
     assert QtWidgets.QTextEdit.setTabStopWidth
@@ -37,9 +33,6 @@ def test_what_moved_to_qtgui_in_qt6():
     assert QtWidgets.QUndoCommand is not None
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_qplaintextedit_functions(qtbot, pdf_writer):
     """Test functions mapping for QtWidgets.QPlainTextEdit."""
     assert QtWidgets.QPlainTextEdit.setTabStopWidth
@@ -53,9 +46,6 @@ def test_qplaintextedit_functions(qtbot, pdf_writer):
     assert output_path.exists()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 def test_QApplication_exec_():
     """Test `QtWidgets.QApplication.exec_`"""
     assert QtWidgets.QApplication.exec_ is not None
@@ -70,9 +60,6 @@ def test_QApplication_exec_():
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
-@pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")
 def test_qdialog_functions(qtbot):
@@ -83,9 +70,6 @@ def test_qdialog_functions(qtbot):
     dialog.exec_()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 @pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")
@@ -102,9 +86,6 @@ def test_qdialog_subclass(qtbot):
     dialog.exec_()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Fatal Python error: Aborted on Linux CI when not using conda")
 @pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
     reason="Stalls on macOS CI with Python 3.7")

--- a/qtpy/tests/test_uic.py
+++ b/qtpy/tests/test_uic.py
@@ -12,7 +12,6 @@ if PYSIDE2:
     pytest.importorskip("pyside2uic", reason="pyside2uic not installed")
 
 from qtpy import uic
-from qtpy.tests.utils import not_using_conda
 
 
 QCOMBOBOX_SUBCLASS = """
@@ -42,9 +41,6 @@ def enabled_qcombobox_subclass(temp_dir_path):
     sys.path.pop(0)
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Segfaults on Linux when not using conda under all bindings (PYSIDE2/6 & PYQT5/6)")
 def test_load_ui(qtbot):
     """
     Make sure that the patched loadUi function behaves as expected with a
@@ -62,9 +58,6 @@ def test_load_ui(qtbot):
 @pytest.mark.skipif(
     PYSIDE2 or PYSIDE6,
     reason="PySide2uic not consistently installed across platforms/versions")
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Segfaults on Linux when not using conda under all bindings (PYSIDE2/6 & PYQT5/6)")
 def test_load_ui_type(qtbot):
     """
     Make sure that the patched loadUiType function behaves as expected with a
@@ -88,9 +81,6 @@ def test_load_ui_type(qtbot):
     assert isinstance(ui.comboBox, QComboBox)
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') and not_using_conda(),
-    reason="Segfaults on Linux when not using conda under all bindings (PYSIDE2/6 & PYQT5/6)")
 def test_load_ui_custom_auto(qtbot, tmp_path):
     """
     Test that we can load a .ui file with custom widgets without having to


### PR DESCRIPTION
In this PR I have added installation of libs required by qt to setup `QApplication`. For this, I have used [`tlambert03/setup-qt-libs@v1` ](https://github.com/tlambert03/setup-qt-libs). This action is used in few projects testing Qt (like napari) so if new Qt version requires some additional library it will be added without the need to make such a patch in all projects. 