### PR TITLE
PR: Make `QMenu.addAction` and `QToolBar.addAction` compatible with Qt6 arguments' order

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -7,10 +7,13 @@
 # -----------------------------------------------------------------------------
 
 """Provides widget classes and functions."""
-from functools import wraps
+from functools import partialmethod, wraps
+
+from packaging.version import parse
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
 from ._utils import add_action, possibly_static_exec, getattr_missing_optional_dep
+from .QtCore import __version__ as _qt_version
 
 
 _missing_optional_names = {}
@@ -115,10 +118,7 @@ else:
     QFileDialog.getOpenFileNames = _dir_to_directory(QFileDialog.getOpenFileNames)
     QFileDialog.getSaveFileName = _dir_to_directory(QFileDialog.getSaveFileName)
 
-
-# Make `addAction` compatible with Qt6
-if PYQT5 or PYSIDE2:
-    from functools import partialmethod
-
+# Make `addAction` compatible with Qt6 >= 6.3
+if PYQT5 or PYSIDE2 or parse(_qt_version) < parse('6.3'):
     QMenu.addAction = partialmethod(add_action, old_add_action=QMenu.addAction)
     QToolBar.addAction = partialmethod(add_action, old_add_action=QToolBar.addAction)

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -10,7 +10,7 @@
 from functools import wraps
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
-from ._utils import possibly_static_exec, getattr_missing_optional_dep
+from ._utils import add_action, possibly_static_exec, getattr_missing_optional_dep
 
 
 _missing_optional_names = {}
@@ -114,3 +114,11 @@ else:
     QFileDialog.getOpenFileName = _dir_to_directory(QFileDialog.getOpenFileName)
     QFileDialog.getOpenFileNames = _dir_to_directory(QFileDialog.getOpenFileNames)
     QFileDialog.getSaveFileName = _dir_to_directory(QFileDialog.getSaveFileName)
+
+
+# Make `addAction` compatible with Qt6
+if PYQT5 or PYSIDE2:
+    from functools import partialmethod
+
+    QMenu.addAction = partialmethod(add_action, old_add_action=QMenu.addAction)
+    QToolBar.addAction = partialmethod(add_action, old_add_action=QToolBar.addAction)

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -11,9 +11,8 @@ from functools import partialmethod, wraps
 
 from packaging.version import parse
 
-from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QtModuleNotInstalledError
+from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, QT_VERSION as _qt_version
 from ._utils import add_action, possibly_static_exec, getattr_missing_optional_dep
-from .QtCore import __version__ as _qt_version
 
 
 _missing_optional_names = {}

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -61,6 +61,7 @@ def possibly_static_exec_(cls, *args, **kwargs):
 
 
 def add_action(self, *args, old_add_action):
+    """Re-order arguments of `addAction` to backport compatibility with Qt>=6.3."""
     from qtpy.QtCore import QObject
     from qtpy.QtGui import QIcon, QKeySequence
     from qtpy.QtWidgets import QAction

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -44,3 +44,57 @@ def possibly_static_exec(cls, *args, **kwargs):
         return args[0].exec(*args[1:], **kwargs)
     else:
         return cls.exec(*args, **kwargs)
+
+
+def add_action(self, *args, old_add_action):
+    from qtpy.QtCore import QObject
+    from qtpy.QtGui import QIcon, QKeySequence
+    from qtpy.QtWidgets import QAction
+
+    action: QAction
+    icon: QIcon
+    text: str
+    shortcut: QKeySequence | QKeySequence.StandardKey | str | int
+    receiver: QObject
+    member: bytes
+    if all(isinstance(arg, t)
+           for arg, t in zip(args, [str,
+                                    (QKeySequence, QKeySequence.StandardKey, str, int),
+                                    QObject,
+                                    bytes])):
+        if len(args) == 2:
+            text, shortcut = args
+            action = old_add_action(self, text)
+            action.setShortcut(shortcut)
+        elif len(args) == 3:
+            text, shortcut, receiver = args
+            action = old_add_action(self, text, receiver)
+            action.setShortcut(shortcut)
+        elif len(args) == 4:
+            text, shortcut, receiver, member = args
+            action = old_add_action(self, text, receiver, member, shortcut)
+        else:
+            return old_add_action(self, *args)
+        return action
+    elif all(isinstance(arg, t)
+             for arg, t in zip(args, [QIcon,
+                                      str,
+                                      (QKeySequence, QKeySequence.StandardKey, str, int),
+                                      QObject,
+                                      bytes])):
+        if len(args) == 3:
+            icon, text, shortcut = args
+            action = old_add_action(self, icon, text)
+            action.setShortcut(QKeySequence(shortcut))
+        elif len(args) == 4:
+            icon, text, shortcut, receiver = args
+            action = old_add_action(self, icon, text, receiver)
+            action.setShortcut(QKeySequence(shortcut))
+        elif len(args) == 5:
+            icon, text, shortcut, receiver, member = args
+            action = old_add_action(self, icon, text, receiver, member, QKeySequence(shortcut))
+        else:
+            return old_add_action(self, *args)
+        return action
+    return old_add_action(self, *args)
+

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -123,8 +123,8 @@ def test_QMenu_functions(qtbot):
 def test_QToolBar_functions(qtbot):
     """Test `QtWidgets.QToolBar.addAction` compatibility with Qt6 arguments' order."""
     toolbar = QtWidgets.QToolBar()
-    toolbar.addAction('QtPy with a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
-    toolbar.addAction(QtGui.QIcon(), 'QtPy with an icon and a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
+    toolbar.addAction('QtPy with a shortcut', QtGui.QKeySequence.UnknownKey)
+    toolbar.addAction(QtGui.QIcon(), 'QtPy with an icon and a shortcut', QtGui.QKeySequence.UnknownKey)
 
 
 @pytest.mark.skipif(PYQT5 and PYQT_VERSION.startswith('5.9'),

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -100,6 +100,8 @@ def test_QMenu_functions(qtbot):
     window = QtWidgets.QMainWindow()
     menu = QtWidgets.QMenu(window)
     menu.addAction('QtPy')
+    menu.addAction('QtPy with a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
+    menu.addAction(QtGui.QIcon(), 'QtPy with an icon and a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
     window.show()
 
     with qtbot.waitExposed(window):
@@ -113,6 +115,16 @@ def test_QMenu_functions(qtbot):
             QtCore.Qt.Key_Escape)
         )
         QtWidgets.QMenu.exec_(menu.actions(), QtCore.QPoint(1, 1))
+
+
+@pytest.mark.skipif(
+    sys.platform == 'darwin' and sys.version_info[:2] == (3, 7),
+    reason="Stalls on macOS CI with Python 3.7")
+def test_QToolBar_functions(qtbot):
+    """Test `QtWidgets.QToolBar.addAction` compatibility with Qt6 arguments' order."""
+    toolbar = QtWidgets.QToolBar()
+    toolbar.addAction('QtPy with a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
+    toolbar.addAction(QtGui.QIcon(), 'QtPy with an icon and a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
 
 
 @pytest.mark.skipif(PYQT5 and PYQT_VERSION.startswith('5.9'),

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -100,8 +100,8 @@ def test_QMenu_functions(qtbot):
     window = QtWidgets.QMainWindow()
     menu = QtWidgets.QMenu(window)
     menu.addAction('QtPy')
-    menu.addAction('QtPy with a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
-    menu.addAction(QtGui.QIcon(), 'QtPy with an icon and a shortcut', QtGui.QKeySequence.StandardKey.UnknownKey)
+    menu.addAction('QtPy with a shortcut', QtGui.QKeySequence.UnknownKey)
+    menu.addAction(QtGui.QIcon(), 'QtPy with an icon and a shortcut', QtGui.QKeySequence.UnknownKey)
     window.show()
 
     with qtbot.waitExposed(window):


### PR DESCRIPTION
Surprisingly, I've stumbled upon that in Qt5 and Qt6, `addAction` accepts arguments in different order. So, here's the monkey patch for that.

I've checked other derivatives of `QWidget`, and only `QMenu`, `QToolBar`, and `QLineEdit` have non-trivial `addAction`. I haven't patched the latter, for it hasn't changed between Qt5 and Qt6. So, this is the patch for `QMenu` and `QToolBar`.

I don't actually know how to use the `receiver: QObject` and the `member: bytes` arguments of `addAction`, so I haven't tested them.