### PR TITLE
Make `exec()` for PySide2

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -10,7 +10,7 @@
 from typing import TYPE_CHECKING
 
 from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6
-from ._utils import possibly_static_exec
+from ._utils import possibly_static_exec, possibly_static_exec_
 
 if PYQT5:
     from PyQt5.QtCore import *
@@ -76,6 +76,11 @@ elif PYSIDE2:
         except ImportError:
             # Fails with PySide2 5.12.0
             pass
+
+    QCoreApplication.exec = lambda *args, **kwargs: possibly_static_exec_(QCoreApplication, *args, **kwargs)
+    QEventLoop.exec = lambda self, *args, **kwargs: self.exec_(*args, **kwargs)
+    QThread.exec = lambda self, *args, **kwargs: self.exec_(*args, **kwargs)
+    QTextStreamManipulator.exec = lambda self, *args, **kwargs: self.exec_(*args, **kwargs)
 
 elif PYSIDE6:
     from PySide6.QtCore import *

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -44,3 +44,17 @@ def possibly_static_exec(cls, *args, **kwargs):
         return args[0].exec(*args[1:], **kwargs)
     else:
         return cls.exec(*args, **kwargs)
+
+
+def possibly_static_exec_(cls, *args, **kwargs):
+    """Call `self.exec` when `self` is given or a static method otherwise."""
+    if not args and not kwargs:
+        # A special case (`cls.exec()`) to avoid the function resolving error
+        return cls.exec_()
+    if isinstance(args[0], cls):
+        if len(args) == 1 and not kwargs:
+            # A special case (`self.exec()`) to avoid the function resolving error
+            return args[0].exec_()
+        return args[0].exec_(*args[1:], **kwargs)
+    else:
+        return cls.exec_(*args, **kwargs)

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -53,17 +53,21 @@ def test_QTime_toPython_and_toPyTime(method):
     assert py_time == NOW.time()
 
 
-def test_qeventloop_exec_(qtbot):
-    """Test QEventLoop.exec_"""
+def test_qeventloop_exec(qtbot):
+    """Test `QEventLoop.exec_` and `QEventLoop.exec`"""
     assert QtCore.QEventLoop.exec_ is not None
+    assert QtCore.QEventLoop.exec is not None
     event_loop = QtCore.QEventLoop(None)
     QtCore.QTimer.singleShot(100, event_loop.quit)
     event_loop.exec_()
+    QtCore.QTimer.singleShot(100, event_loop.quit)
+    event_loop.exec()
 
 
-def test_qthread_exec_():
-    """Test QThread.exec_"""
+def test_qthread_exec():
+    """Test `QThread.exec_` and `QThread.exec_`"""
     assert QtCore.QThread.exec_ is not None
+    assert QtCore.QThread.exec is not None
 
 
 def test_QLibraryInfo_location_and_path():
@@ -93,11 +97,25 @@ def test_QCoreApplication_exec_(qapp):
     app.exec_()
 
 
+def test_QCoreApplication_exec(qapp):
+    """Test `QtCore.QCoreApplication.exec`"""
+    assert QtCore.QCoreApplication.exec is not None
+    app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtCore.QCoreApplication.instance().quit)
+    QtCore.QCoreApplication.exec()
+    app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([sys.executable, __file__])
+    assert app is not None
+    QtCore.QTimer.singleShot(100, QtCore.QCoreApplication.instance().quit)
+    app.exec()
+
+
 @pytest.mark.skipif(PYQT5 or PYQT6,
                     reason="Doesn't seem to be present on PyQt5 and PyQt6")
-def test_qtextstreammanipulator_exec_():
-    """Test QTextStreamManipulator.exec_"""
-    QtCore.QTextStreamManipulator.exec_ is not None
+def test_qtextstreammanipulator_exec():
+    """Test `QTextStreamManipulator.exec_` and `QTextStreamManipulator.exec`"""
+    assert QtCore.QTextStreamManipulator.exec_ is not None
+    assert QtCore.QTextStreamManipulator.exec is not None
 
 
 @pytest.mark.skipif(PYSIDE2 or PYQT6,


### PR DESCRIPTION
To make the new code compatible with `PySide2`, I've made `exec()` for the classes that have `exec_()` functions:
- `QCoreApplication`
- `QEventLoop`
- `QThread`
- `QTextStreamManipulator`

And tests for the calls. Actually, `test_qtextstreammanipulator_exec` and `test_qthread_exec` are far from perfect, but I haven't figured out how to test them.