### PR TITLE
PR: Update bindings upper bound version to 6.5 and ignore `DeprecationWarning` (CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           pyside6-version: '6.4'  # Python 3.11 needs 6.4+
         - use-conda: 'Yes'
           skip-pyqt6: true  # No PyQt6 conda packages yet
-          pyside6-version: '6.4'  # Conda only has 6.4+
+          pyside6-version: '6.4'  # Conda only has 6.4+ for Python <3.8
         - use-conda: 'No'
           pyqt5-version: '5.15'  # Test with latest optional packages
         - python-version: '3.7'
@@ -67,6 +67,7 @@ jobs:
         - python-version: '3.11'
           use-conda: 'No'
           skip-pyside2: true  # Pyside2 wheels don't support Python 3.11+
+          pyside6-version: '6.5'  # Test upper bound
         - os: windows-latest
           python-version: '3.7'
           use-conda: 'Yes'
@@ -84,7 +85,7 @@ jobs:
         - os: macos-latest
           python-version: '3.7'
           use-conda: 'No'
-          pyqt6-version: 6.4  # Test upper bound
+          pyqt6-version: 6.5  # Test upper bound
           pyside2-version: 5.15  # Test upper bound
     steps:
       - name: Checkout branch

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -53,11 +53,12 @@ fi
 
 # Build wheel of package
 git clean -xdf -e *.coverage
+python -m pip install --upgrade pip
 python -m pip install --upgrade build
 python -bb -X dev -W error -m build
 
 # Install package from built wheel
-echo dist/*.whl | xargs -I % python -bb -X dev -W error -W "ignore::DeprecationWarning:pip._internal.locations._distutils" -W "ignore::DeprecationWarning:distutils.command.install" -m pip install --upgrade %
+echo dist/*.whl | xargs -I % python -bb -X dev -W error -W "ignore::DeprecationWarning:pip._internal.locations._distutils" -W "ignore::DeprecationWarning:distutils.command.install" -W "ignore::DeprecationWarning:pip._internal.metadata.importlib._envs" -m pip install --upgrade %
 
 # Print environment information
 mamba list


### PR DESCRIPTION
* Move macOS CI job with Python 3.7 and pip to use PyQt6 6.5+
* Move CI jobs with Python 3.11 and pip to use PySide6 6.5+
* Ignore `DeprecationWarning` raised inside `pip` vendored `pkg_resources` version (`DeprecationWarning: pkg_resources is deprecated as an API.` message)

Part of #442 