### PR TITLE
PR: Restore `Qt.ItemFlags` access as `Qt.ItemFlag` alias (PyQt6)

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -60,6 +60,10 @@ elif PYQT6:
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
     # Alias for MiddleButton removed in PyQt6 but available in PyQt5, PySide2 and PySide6
     Qt.MidButton = Qt.MiddleButton
+    # Add removed definition for `Qt.ItemFlags` as an alias of `Qt.ItemFlag` as PySide6 does.
+    # Note that for PyQt5 and PySide2 those definitions are two different classes
+    # (one is the flag definition and the other the enum definition)
+    Qt.ItemFlags = Qt.ItemFlag
 
 elif PYSIDE2:
     from PySide2.QtCore import *

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -58,8 +58,10 @@ elif PYQT6:
     # Alias deprecated ItemDataRole enum values removed in Qt6
     Qt.BackgroundColorRole = Qt.ItemDataRole.BackgroundColorRole = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
+
     # Alias for MiddleButton removed in PyQt6 but available in PyQt5, PySide2 and PySide6
     Qt.MidButton = Qt.MiddleButton
+
     # Add removed definition for `Qt.ItemFlags` as an alias of `Qt.ItemFlag` as PySide6 does.
     # Note that for PyQt5 and PySide2 those definitions are two different classes
     # (one is the flag definition and the other the enum definition)

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -146,7 +146,6 @@ def test_enum_access():
     assert QtCore.Qt.TextColorRole == QtCore.Qt.ItemDataRole.TextColorRole
     assert QtCore.Qt.MidButton == QtCore.Qt.MouseButton.MiddleButton
 
-
 @pytest.mark.skipif(PYSIDE2 and PYSIDE_VERSION.startswith('5.12.0'),
                     reason="Utility functions unavailable for PySide2 5.12.0")
 def test_qtgui_namespace_mightBeRichText():
@@ -156,3 +155,10 @@ def test_qtgui_namespace_mightBeRichText():
     See: https://doc.qt.io/qt-5/qt-sub-qtgui.html
     """
     assert QtCore.Qt.mightBeRichText is not None
+
+
+def test_itemflags_typedef():
+    """
+    Test existence of `QFlags<ItemFlag>` typedef `ItemFlags` that was removed from PyQt6
+    """
+    assert QtCore.Qt.ItemFlags is not None


### PR DESCRIPTION
Part of #442 