### PR TITLE
PR: Add mappings for deprecated `QDropEvent` `pos` and `posF` methods

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -137,8 +137,8 @@ if PYSIDE2 or PYSIDE6:
         return movePosition(self, operation, mode, n)
     QTextCursor.movePosition = movePositionPatched
 
-# Fix https://github.com/spyder-ide/qtpy/issues/394
 if PYQT5 or PYSIDE2:
+    # Part of the fix for https://github.com/spyder-ide/qtpy/issues/394
     from qtpy.QtCore import QPointF as __QPointF
     QNativeGestureEvent.x = lambda self: self.localPos().toPoint().x()
     QNativeGestureEvent.y = lambda self: self.localPos().toPoint().y()
@@ -160,7 +160,11 @@ if PYQT5 or PYSIDE2:
     QMouseEvent.position = lambda self: self.localPos()
     QMouseEvent.globalPosition = lambda self: __QPointF(
         float(self.globalX()), float(self.globalY()))
+
+    # Follow similar approach for `QDropEvent` and child classes
+    QDropEvent.position = lambda self: self.posF()
 if PYQT6 or PYSIDE6:
+    # Part of the fix for https://github.com/spyder-ide/qtpy/issues/394
     for _class in (QNativeGestureEvent, QEnterEvent, QTabletEvent, QHoverEvent,
                    QMouseEvent):
         for _obsolete_function in ('pos', 'x', 'y', 'globalPos', 'globalX', 'globalY'):
@@ -175,3 +179,6 @@ if PYQT6 or PYSIDE6:
     QSinglePointEvent.globalX = lambda self: self.globalPosition().toPoint().x()
     QSinglePointEvent.globalY = lambda self: self.globalPosition().toPoint().y()
 
+    # Follow similar approach for `QDropEvent` and child classes
+    QDropEvent.pos = lambda self: self.position().toPoint()
+    QDropEvent.posF = lambda self: self.position()

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -102,12 +102,18 @@ def test_QSomethingEvent_pos_functions(qtbot):
         qtbot.mouseDClick(window, QtCore.Qt.LeftButton)
 
     # the rest of the functions are not actually tested
+    # QSinglePointEvent (Qt6) child classes checks
     for _class in ('QNativeGestureEvent', 'QEnterEvent', 'QTabletEvent'):
         for _function in ('pos', 'x', 'y', 'globalPos', 'globalX', 'globalY',
                           'position', 'globalPosition'):
             assert hasattr(getattr(QtGui, _class), _function)
+    # QHoverEvent checks
     for _function in ('pos', 'x', 'y', 'position'):
         assert hasattr(QtGui.QHoverEvent, _function)
+    # QDropEvent and child classes checks
+    for _class in ('QDropEvent', 'QDragMoveEvent', 'QDragEnterEvent'):
+        for _function in ('pos', 'posF', 'position'):
+            assert hasattr(getattr(QtGui, _class), _function)
 
 
 @pytest.mark.skipif(not (PYSIDE2 or PYSIDE6), reason="PySide{2,6} specific test")

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -107,9 +107,11 @@ def test_QSomethingEvent_pos_functions(qtbot):
         for _function in ('pos', 'x', 'y', 'globalPos', 'globalX', 'globalY',
                           'position', 'globalPosition'):
             assert hasattr(getattr(QtGui, _class), _function)
+
     # QHoverEvent checks
     for _function in ('pos', 'x', 'y', 'position'):
         assert hasattr(QtGui.QHoverEvent, _function)
+
     # QDropEvent and child classes checks
     for _class in ('QDropEvent', 'QDragMoveEvent', 'QDragEnterEvent'):
         for _function in ('pos', 'posF', 'position'):


### PR DESCRIPTION
Mappings for `pos` and `posF` for `QDropEvent` also affect child classes (`QDragMoveEvent`, `QDragEnterEvent`). A mapping to have `position` over Qt5 bindings is done too.

Part of #442 