### PR TITLE
PR: Restore `QtWidgets.QFileDialog.Options` access as `QtWidgets.QFileDialog.Option` alias (PyQt6)

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -71,6 +71,9 @@ elif PYQT6:
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)
     QLineEdit.getTextMargins = lambda self: (self.textMargins().left(), self.textMargins().top(), self.textMargins().right(), self.textMargins().bottom())
 
+    # Map missing flags definitions
+    QFileDialog.Options = QFileDialog.Option
+
     # Allow unscoped access for enums inside the QtWidgets module
     from .enums_compat import promote_enums
     promote_enums(QtWidgets)

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -155,7 +155,7 @@ def test_opengl_imports():
     reason="Crashes on macOS with Python 3.7 with 'Illegal instruction: 4'")
 @pytest.mark.parametrize("keyword", ["dir", "directory"])
 @pytest.mark.parametrize("instance", [True, False])
-def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
+def test_qfiledialog_dir_compat(tmp_path, qtbot, keyword, instance):
     """
     This function is testing if the decorators that renamed the dir/directory
     keyword are working.
@@ -230,3 +230,10 @@ def test_qfiledialog_compat(tmp_path, qtbot, keyword, instance):
     dlg = QtWidgets.QFileDialog() if instance else QtWidgets.QFileDialog
     dlg.getExistingDirectory(**kwargs)
     qtbot.waitUntil(thr.isFinished, timeout=3000)
+
+
+def test_qfiledialog_flags_typedef():
+    """
+    Test existence of `QFlags<Option>` typedef `Options` that was removed from PyQt6
+    """
+    assert QtWidgets.QFileDialog.Options is not None


### PR DESCRIPTION
Fixes #442 