### PR TITLE
PR: Improve enum to flags aliasing for PyQt6 and PySide6 > 6.3 and `QFileDialog` static methods kwarg compatibility

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -62,10 +62,11 @@ elif PYQT6:
     # Alias for MiddleButton removed in PyQt6 but available in PyQt5, PySide2 and PySide6
     Qt.MidButton = Qt.MiddleButton
 
-    # Add removed definition for `Qt.ItemFlags` as an alias of `Qt.ItemFlag` as PySide6 does.
+    # Add removed definition for `Qt.ItemFlags` as an alias of `Qt.ItemFlag`
+    # passing as default value 0 in the same way PySide6 does.
     # Note that for PyQt5 and PySide2 those definitions are two different classes
     # (one is the flag definition and the other the enum definition)
-    Qt.ItemFlags = Qt.ItemFlag
+    Qt.ItemFlags = lambda value=0: Qt.ItemFlag(value)
 
 elif PYSIDE2:
     from PySide2.QtCore import *

--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -9,7 +9,9 @@
 """Provides QtCore classes and functions."""
 from typing import TYPE_CHECKING
 
-from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6
+from packaging.version import parse
+
+from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, QT_VERSION as _qt_version
 from ._utils import possibly_static_exec, possibly_static_exec_
 
 if PYQT5:
@@ -63,7 +65,7 @@ elif PYQT6:
     Qt.MidButton = Qt.MiddleButton
 
     # Add removed definition for `Qt.ItemFlags` as an alias of `Qt.ItemFlag`
-    # passing as default value 0 in the same way PySide6 does.
+    # passing as default value 0 in the same way PySide6 6.5+ does.
     # Note that for PyQt5 and PySide2 those definitions are two different classes
     # (one is the flag definition and the other the enum definition)
     Qt.ItemFlags = lambda value=0: Qt.ItemFlag(value)
@@ -110,6 +112,10 @@ elif PYSIDE6:
     QEventLoop.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QThread.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QTextStreamManipulator.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
+
+    # Passing as default value 0 in the same way PySide6 6.3.2 does for the `Qt.ItemFlags` definition.
+    if parse(_qt_version) > parse('6.3'):
+        Qt.ItemFlags = lambda value=0: Qt.ItemFlag(value)
 
 # For issue #153 and updated for issue #305
 if PYQT5 or PYQT6:

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -72,7 +72,7 @@ elif PYQT6:
     QLineEdit.getTextMargins = lambda self: (self.textMargins().left(), self.textMargins().top(), self.textMargins().right(), self.textMargins().bottom())
 
     # Add removed definition for `QFileDialog.Options` as an alias of `QFileDialog.Option`
-    # passing as default value 0 in the same way PySide6 does.
+    # passing as default value 0 in the same way PySide6 6.5+ does.
     # Note that for PyQt5 and PySide2 those definitions are two different classes
     # (one is the flag definition and the other the enum definition)
     QFileDialog.Options = lambda value=0: QFileDialog.Option(value)
@@ -110,6 +110,10 @@ elif PYSIDE6:
     QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(QApplication, *args, **kwargs)
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)
+
+    # Passing as default value 0 in the same way PySide6 < 6.3.2 does for the `QFileDialog.Options` definition.
+    if parse(_qt_version) > parse('6.3'):
+        QFileDialog.Options = lambda value=0: QFileDialog.Option(value)
 
 
 if PYSIDE2 or PYSIDE6:

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -24,6 +24,12 @@ def __getattr__(name):
         name, module_name=__name__, optional_names=_missing_optional_names)
 
 def _dir_to_directory(func):
+    """
+    Helper function to manage `dir` to `directory` `QFileDialog` kwargs change.
+
+    Makes PyQt5/6 `QFileDialog` static methods accept the `dir` kwarg.
+    """
+    @staticmethod
     @wraps(func)
     def _dir_to_directory_(*args, **kwargs):
         if "dir" in kwargs:
@@ -32,6 +38,12 @@ def _dir_to_directory(func):
     return _dir_to_directory_
 
 def _directory_to_dir(func):
+    """
+    Helper function to manaje `directory` to `dir` `QFileDialog` kwargs change.
+
+    Makes PySide2/6 `QFileDialog` static methods accept the `directory` kwarg.
+    """
+    @staticmethod
     @wraps(func)
     def _directory_to_dir_(*args, **kwargs):
         if "directory" in kwargs:

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -71,8 +71,11 @@ elif PYQT6:
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(QMenu, *args, **kwargs)
     QLineEdit.getTextMargins = lambda self: (self.textMargins().left(), self.textMargins().top(), self.textMargins().right(), self.textMargins().bottom())
 
-    # Map missing flags definitions
-    QFileDialog.Options = QFileDialog.Option
+    # Add removed definition for `QFileDialog.Options` as an alias of `QFileDialog.Option`
+    # passing as default value 0 in the same way PySide6 does.
+    # Note that for PyQt5 and PySide2 those definitions are two different classes
+    # (one is the flag definition and the other the enum definition)
+    QFileDialog.Options = lambda value=0: QFileDialog.Option(value)
 
     # Allow unscoped access for enums inside the QtWidgets module
     from .enums_compat import promote_enums

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 
 """Provides utility functions for use by QtPy itself."""
+from functools import wraps
 
 import qtpy
 
@@ -112,3 +113,18 @@ def add_action(self, *args, old_add_action):
             return old_add_action(self, *args)
         return action
     return old_add_action(self, *args)
+
+
+def static_method_kwargs_wrapper(func, from_kwarg_name, to_kwarg_name):
+    """
+    Helper function to manage `from_kwarg_name` to `to_kwarg_name` kwargs name changes in static methods.
+
+    Makes static methods accept the `from_kwarg_name` kwarg as `to_kwarg_name`.
+    """
+    @staticmethod
+    @wraps(func)
+    def _from_kwarg_name_to_kwarg_name_(*args, **kwargs):
+        if from_kwarg_name in kwargs:
+            kwargs[to_kwarg_name] = kwargs.pop(from_kwarg_name)
+        return func(*args, **kwargs)
+    return _from_kwarg_name_to_kwarg_name_

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -162,3 +162,4 @@ def test_itemflags_typedef():
     Test existence of `QFlags<ItemFlag>` typedef `ItemFlags` that was removed from PyQt6
     """
     assert QtCore.Qt.ItemFlags is not None
+    assert QtCore.Qt.ItemFlags() == QtCore.Qt.ItemFlag(0)

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -236,4 +236,5 @@ def test_qfiledialog_flags_typedef():
     """
     Test existence of `QFlags<Option>` typedef `Options` that was removed from PyQt6
     """
-    assert QtWidgets.QFileDialog.Options is not None
+    assert QtWidgets.QFileDialog.Options is not None    
+    assert QtWidgets.QFileDialog.Options() == QtWidgets.QFileDialog.Option(0)


### PR DESCRIPTION
* Follow-up #448 and #444 
* Fix wrapper functions for `QFileDialog` static methods (used for compatibility with the `dir` vs `directory` kwarg specification)

Need for changes discovered at https://github.com/napari/napari/pull/6164#issuecomment-1688468052 and https://github.com/napari/napari/pull/6164#issuecomment-1689044857