### PR TITLE
PR: Fix bug when importing from `PySide6.QtWebEngineCore/QtWebEngineWidgets` (`QWebEngineScrip` vs `QWebEngineScript`) 

### DIFF
--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -64,7 +64,7 @@ elif PYSIDE6:
     from PySide6.QtWebEngineCore import (
         QWebEnginePage,
         QWebEngineProfile,
-        QWebEngineScrip,
+        QWebEngineScript,
         QWebEngineSettings,
     )
     from PySide6.QtWebEngineWidgets import *

--- a/qtpy/tests/test_qtwebenginewidgets.py
+++ b/qtpy/tests/test_qtwebenginewidgets.py
@@ -1,10 +1,14 @@
 import pytest
+from packaging import version
 
-from qtpy import PYQT6, PYSIDE6
+from qtpy import PYQT6, PYQT_VERSION, PYSIDE6, PYSIDE_VERSION
 
 
 @pytest.mark.skipif(
-    PYSIDE6 or PYQT6,
+    not (
+        (PYQT6 and version.parse(PYQT_VERSION) >= version.parse("6.2"))
+        or (PYSIDE6 and version.parse(PYSIDE_VERSION) >= version.parse("6.2"))
+    ),
     reason="Only available in Qt<6,>=6.2 bindings",
 )
 def test_qtwebenginewidgets():

--- a/qtpy/tests/test_qtwebenginewidgets.py
+++ b/qtpy/tests/test_qtwebenginewidgets.py
@@ -1,13 +1,15 @@
 import pytest
 from packaging import version
 
-from qtpy import PYQT6, PYQT_VERSION, PYSIDE6, PYSIDE_VERSION
+from qtpy import PYQT5, PYQT6, PYQT_VERSION, PYSIDE2, PYSIDE6, PYSIDE_VERSION
 
 
 @pytest.mark.skipif(
     not (
         (PYQT6 and version.parse(PYQT_VERSION) >= version.parse("6.2"))
         or (PYSIDE6 and version.parse(PYSIDE_VERSION) >= version.parse("6.2"))
+        or PYQT5
+        or PYSIDE2
     ),
     reason="Only available in Qt<6,>=6.2 bindings",
 )


### PR DESCRIPTION
Fix typo in import statement