### PR TITLE
Fix typo in QtWebEngineWidgets.py imports

### DIFF
--- a/qtpy/QtWebEngineWidgets.py
+++ b/qtpy/QtWebEngineWidgets.py
@@ -64,7 +64,7 @@ elif PYSIDE6:
     from PySide6.QtWebEngineCore import (
         QWebEnginePage,
         QWebEngineProfile,
-        QWebEngineScrip,
+        QWebEngineScript,
         QWebEngineSettings,
     )
     from PySide6.QtWebEngineWidgets import *


### PR DESCRIPTION
Fix a typo in the PySide 6 imports.