### PR TITLE
PR: Make `QAction.setShortcut` and `setShortcuts` accept many types

### DIFF
--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -21,7 +21,6 @@ from ._utils import (
     set_shortcuts,
 )
 
-
 _missing_optional_names = {}
 
 _QTOPENGL_NAMES = {

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -258,8 +258,8 @@ if PYQT6 or PYSIDE6:
     QDropEvent.posF = lambda self: self.position()
 
 
-# Make `QAction.setShortcut` and `QAction.setShortcuts` compatible with Qt>=6.3
-if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.3"):
+# Make `QAction.setShortcut` and `QAction.setShortcuts` compatible with Qt>=6.4
+if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
     from functools import partialmethod
 
     from ._utils import (

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -295,7 +295,8 @@ if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
     )
     QAction.setShortcut = _action_set_shortcut
     QAction.setShortcuts = _action_set_shortcuts
-    if (  # despite the two previous lines!
+    # Despite the two previous lines!
+    if (
         QAction.setShortcut is not _action_set_shortcut
         or QAction.setShortcuts is not _action_set_shortcuts
     ):

--- a/qtpy/QtGui.py
+++ b/qtpy/QtGui.py
@@ -8,12 +8,19 @@
 
 """Provides QtGui classes and functions."""
 
+from functools import partialmethod
 
 from packaging.version import parse
 
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6
 from . import QT_VERSION as _qt_version
-from ._utils import getattr_missing_optional_dep, possibly_static_exec
+from ._utils import (
+    getattr_missing_optional_dep,
+    possibly_static_exec,
+    set_shortcut,
+    set_shortcuts,
+)
+
 
 _missing_optional_names = {}
 
@@ -260,12 +267,6 @@ if PYQT6 or PYSIDE6:
 
 # Make `QAction.setShortcut` and `QAction.setShortcuts` compatible with Qt>=6.4
 if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
-    from functools import partialmethod
-
-    from ._utils import (
-        set_shortcut,
-        set_shortcuts,
-    )
 
     class _QAction(QAction):
         old_set_shortcut = QAction.setShortcut

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -14,6 +14,7 @@ from packaging.version import parse
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6
 from . import QT_VERSION as _qt_version
 from ._utils import (
+    add_action,
     getattr_missing_optional_dep,
     possibly_static_exec,
     static_method_kwargs_wrapper,
@@ -211,7 +212,6 @@ else:
 
 # Make `addAction` compatible with Qt6 >= 6.4
 if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
-    from ._utils import add_action
 
     class _QMenu(QMenu):
         old_add_action = QMenu.addAction

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -37,14 +37,14 @@ if PYQT5:
 elif PYQT6:
     from PyQt6 import QtWidgets
     from PyQt6.QtWidgets import *
-
-    from qtpy.QtGui import (
-        QAction,
+    from PyQt6.QtGui import (
         QActionGroup,
         QFileSystemModel,
         QShortcut,
         QUndoCommand,
     )
+
+    from qtpy.QtGui import QAction  # See spyder-ide/qtpy#461
 
     # Attempt to import QOpenGLWidget, but if that fails,
     # don't raise an exception until the name is explicitly accessed.
@@ -112,8 +112,9 @@ elif PYSIDE2:
     from PySide2.QtWidgets import *
 elif PYSIDE6:
     from PySide6.QtWidgets import *
+    from PySide6.QtGui import QActionGroup, QShortcut, QUndoCommand
 
-    from qtpy.QtGui import QAction, QActionGroup, QShortcut, QUndoCommand
+    from qtpy.QtGui import QAction  # See spyder-ide/qtpy#461
 
     # Attempt to import QOpenGLWidget, but if that fails,
     # don't raise an exception until the name is explicitly accessed.

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -228,7 +228,8 @@ if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
         old_add_action=QMenu.addAction,
     )
     QMenu.addAction = _menu_add_action
-    if QMenu.addAction is not _menu_add_action:  # despite the previous line!
+    # Despite the previous line!
+    if QMenu.addAction is not _menu_add_action:
         QMenu = _QMenu
 
     class _QToolBar(QToolBar):
@@ -246,7 +247,6 @@ if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
         old_add_action=QToolBar.addAction,
     )
     QToolBar.addAction = _toolbar_add_action
-    if (  # despite the previous line!
-        QToolBar.addAction is not _toolbar_add_action
-    ):
+    # Despite the previous line!
+    if QToolBar.addAction is not _toolbar_add_action:
         QToolBar = _QToolBar

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -38,6 +38,8 @@ if PYQT5:
     from PyQt5.QtWidgets import *
 elif PYQT6:
     from PyQt6 import QtWidgets
+    from PyQt6.QtWidgets import *
+
     from qtpy.QtGui import (
         QAction,
         QActionGroup,
@@ -45,7 +47,6 @@ elif PYQT6:
         QShortcut,
         QUndoCommand,
     )
-    from PyQt6.QtWidgets import *
 
     # Attempt to import QOpenGLWidget, but if that fails,
     # don't raise an exception until the name is explicitly accessed.
@@ -112,8 +113,9 @@ elif PYQT6:
 elif PYSIDE2:
     from PySide2.QtWidgets import *
 elif PYSIDE6:
-    from qtpy.QtGui import QAction, QActionGroup, QShortcut, QUndoCommand
     from PySide6.QtWidgets import *
+
+    from qtpy.QtGui import QAction, QActionGroup, QShortcut, QUndoCommand
 
     # Attempt to import QOpenGLWidget, but if that fails,
     # don't raise an exception until the name is explicitly accessed.

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -38,7 +38,7 @@ if PYQT5:
     from PyQt5.QtWidgets import *
 elif PYQT6:
     from PyQt6 import QtWidgets
-    from PyQt6.QtGui import (
+    from qtpy.QtGui import (
         QAction,
         QActionGroup,
         QFileSystemModel,
@@ -112,7 +112,7 @@ elif PYQT6:
 elif PYSIDE2:
     from PySide2.QtWidgets import *
 elif PYSIDE6:
-    from PySide6.QtGui import QAction, QActionGroup, QShortcut, QUndoCommand
+    from qtpy.QtGui import QAction, QActionGroup, QShortcut, QUndoCommand
     from PySide6.QtWidgets import *
 
     # Attempt to import QOpenGLWidget, but if that fails,
@@ -250,41 +250,3 @@ if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.3"):
         QToolBar.addAction is not _toolbar_add_action
     ):
         QToolBar = _QToolBar
-
-
-# Make `QAction.setShortcut` and `QAction.setShortcuts` compatible with Qt>=6.3
-if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.3"):
-
-    class _QAction(QAction):
-        old_set_shortcut = QAction.setShortcut
-        old_set_shortcuts = QAction.setShortcuts
-
-        def setShortcut(self, shortcut):
-            return set_shortcut(
-                self,
-                shortcut,
-                old_set_shortcut=_QAction.old_set_shortcut,
-            )
-
-        def setShortcuts(self, shortcuts):
-            return set_shortcuts(
-                self,
-                shortcuts,
-                old_set_shortcuts=_QAction.old_set_shortcuts,
-            )
-
-    _action_set_shortcut = partialmethod(
-        set_shortcut,
-        old_set_shortcut=QAction.setShortcut,
-    )
-    _action_set_shortcuts = partialmethod(
-        set_shortcuts,
-        old_set_shortcuts=QAction.setShortcuts,
-    )
-    QAction.setShortcut = _action_set_shortcut
-    QAction.setShortcuts = _action_set_shortcuts
-    if (  # despite the two previous lines!
-        QAction.setShortcut is not _action_set_shortcut
-        or QAction.setShortcuts is not _action_set_shortcuts
-    ):
-        QAction = _QAction

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -36,13 +36,13 @@ if PYQT5:
     from PyQt5.QtWidgets import *
 elif PYQT6:
     from PyQt6 import QtWidgets
-    from PyQt6.QtWidgets import *
     from PyQt6.QtGui import (
         QActionGroup,
         QFileSystemModel,
         QShortcut,
         QUndoCommand,
     )
+    from PyQt6.QtWidgets import *
 
     from qtpy.QtGui import QAction  # See spyder-ide/qtpy#461
 
@@ -111,8 +111,8 @@ elif PYQT6:
 elif PYSIDE2:
     from PySide2.QtWidgets import *
 elif PYSIDE6:
-    from PySide6.QtWidgets import *
     from PySide6.QtGui import QActionGroup, QShortcut, QUndoCommand
+    from PySide6.QtWidgets import *
 
     from qtpy.QtGui import QAction  # See spyder-ide/qtpy#461
 

--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -14,11 +14,8 @@ from packaging.version import parse
 from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6
 from . import QT_VERSION as _qt_version
 from ._utils import (
-    add_action,
     getattr_missing_optional_dep,
     possibly_static_exec,
-    set_shortcut,
-    set_shortcuts,
     static_method_kwargs_wrapper,
 )
 
@@ -212,8 +209,9 @@ else:
         "directory",
     )
 
-# Make `addAction` compatible with Qt6 >= 6.3
-if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.3"):
+# Make `addAction` compatible with Qt6 >= 6.4
+if PYQT5 or PYSIDE2 or parse(_qt_version) < parse("6.4"):
+    from ._utils import add_action
 
     class _QMenu(QMenu):
         old_add_action = QMenu.addAction

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -86,7 +86,8 @@ def set_shortcuts(self, shortcuts, old_set_shortcuts):
     from qtpy.QtGui import QKeySequence
 
     if isinstance(
-        shortcuts, (QKeySequence, QKeySequence.StandardKey, Qt.Key, int, str),
+        shortcuts,
+        (QKeySequence, QKeySequence.StandardKey, Qt.Key, int, str),
     ):
         shortcuts = (shortcuts,)
 

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -86,7 +86,7 @@ def set_shortcuts(self, shortcuts, old_set_shortcuts):
     from qtpy.QtGui import QKeySequence
 
     if isinstance(
-        shortcuts, (QKeySequence, QKeySequence.StandardKey, Qt.Key, int, str)
+        shortcuts, (QKeySequence, QKeySequence.StandardKey, Qt.Key, int, str),
     ):
         shortcuts = (shortcuts,)
 

--- a/qtpy/_utils.py
+++ b/qtpy/_utils.py
@@ -70,24 +70,56 @@ def possibly_static_exec_(cls, *args, **kwargs):
     return cls.exec_(*args, **kwargs)
 
 
+def set_shortcut(self, shortcut, old_set_shortcut):
+    """Ensure that the type of `shortcut` is compatible to `QAction.setShortcut`."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtGui import QKeySequence
+
+    if isinstance(shortcut, (QKeySequence.StandardKey, Qt.Key, int)):
+        shortcut = QKeySequence(shortcut)
+    old_set_shortcut(self, shortcut)
+
+
+def set_shortcuts(self, shortcuts, old_set_shortcuts):
+    """Ensure that the type of `shortcuts` is compatible to `QAction.setShortcuts`."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtGui import QKeySequence
+
+    if isinstance(
+        shortcuts, (QKeySequence, QKeySequence.StandardKey, Qt.Key, int, str)
+    ):
+        shortcuts = (shortcuts,)
+
+    shortcuts = tuple(
+        (
+            QKeySequence(shortcut)
+            if isinstance(shortcut, (QKeySequence.StandardKey, Qt.Key, int))
+            else shortcut
+        )
+        for shortcut in shortcuts
+    )
+    old_set_shortcuts(self, shortcuts)
+
+
 def add_action(self, *args, old_add_action):
     """Re-order arguments of `addAction` to backport compatibility with Qt>=6.3."""
-    from qtpy.QtCore import QObject
+    from qtpy.QtCore import QObject, Qt
     from qtpy.QtGui import QIcon, QKeySequence
 
     action: QAction
     icon: QIcon
     text: str
-    shortcut: QKeySequence | QKeySequence.StandardKey | str | int
+    shortcut: QKeySequence | QKeySequence.StandardKey | Qt.Key | str | int
     receiver: QObject
     member: bytes
+
     if all(
         isinstance(arg, t)
         for arg, t in zip(
             args,
             [
                 str,
-                (QKeySequence, QKeySequence.StandardKey, str, int),
+                (QKeySequence, QKeySequence.StandardKey, Qt.Key, str, int),
                 QObject,
                 bytes,
             ],
@@ -105,16 +137,15 @@ def add_action(self, *args, old_add_action):
             text, shortcut, receiver, member = args
             action = old_add_action(self, text, receiver, member, shortcut)
         else:
-            return old_add_action(self, *args)
-        return action
-    if all(
+            action = old_add_action(self, *args)
+    elif all(
         isinstance(arg, t)
         for arg, t in zip(
             args,
             [
                 QIcon,
                 str,
-                (QKeySequence, QKeySequence.StandardKey, str, int),
+                (QKeySequence, QKeySequence.StandardKey, Qt.Key, str, int),
                 QObject,
                 bytes,
             ],
@@ -123,11 +154,11 @@ def add_action(self, *args, old_add_action):
         if len(args) == 3:
             icon, text, shortcut = args
             action = old_add_action(self, icon, text)
-            action.setShortcut(QKeySequence(shortcut))
+            action.setShortcut(shortcut)
         elif len(args) == 4:
             icon, text, shortcut, receiver = args
             action = old_add_action(self, icon, text, receiver)
-            action.setShortcut(QKeySequence(shortcut))
+            action.setShortcut(shortcut)
         elif len(args) == 5:
             icon, text, shortcut, receiver, member = args
             action = old_add_action(
@@ -136,12 +167,14 @@ def add_action(self, *args, old_add_action):
                 text,
                 receiver,
                 member,
-                QKeySequence(shortcut),
+                shortcut,
             )
         else:
-            return old_add_action(self, *args)
-        return action
-    return old_add_action(self, *args)
+            action = old_add_action(self, *args)
+    else:
+        action = old_add_action(self, *args)
+
+    return action
 
 
 def static_method_kwargs_wrapper(func, from_kwarg_name, to_kwarg_name):

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -3,12 +3,14 @@
 import sys
 
 import pytest
+from packaging.version import parse
 
 from qtpy import (
     PYQT5,
     PYQT_VERSION,
     PYSIDE2,
     PYSIDE6,
+    QT_VERSION,
     QtCore,
     QtGui,
     QtWidgets,
@@ -189,9 +191,26 @@ def test_QAction_functions(qtbot):
     action.setShortcuts(QtGui.QKeySequence.UnknownKey)
     action.setShortcut(QtCore.Qt.Key_F1)
     action.setShortcuts([QtCore.Qt.Key_F1])
-    # The following line is wrong even for Qt6 == 6.6.
+    # The following line fails even for Qt6 == 6.6.
     # Don't test the function with a single `QtCore.Qt.Key` argument.
+    # See the following test.
     # action.setShortcuts(QtCore.Qt.Key_F1)
+
+
+@pytest.mark.skipif(
+    parse(QT_VERSION) < parse('6.5.0'),
+    reason="Qt6 >= 6.5 specific test",
+)
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info[:2] == (3, 7),
+    reason="Stalls on macOS CI with Python 3.7",
+)
+@pytest.mark.xfail(strict=True)
+def test_QAction_functions_fail(qtbot):
+    """Test `QtGui.QAction.setShortcuts` compatibility with `QtCore.Qt.Key` type."""
+    action = QtGui.QAction("QtPy", None)
+    # The following line is wrong even for Qt6 == 6.6.
+    action.setShortcuts(QtCore.Qt.Key_F1)
 
 
 def test_opengl_imports():

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -177,6 +177,22 @@ def test_qtextcursor_moveposition():
     assert cursor.selectedText() == "foo bar baz"
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info[:2] == (3, 7),
+    reason="Stalls on macOS CI with Python 3.7",
+)
+def test_QAction_functions(qtbot):
+    """Test `QtGui.QAction.setShortcut` compatibility with Qt6 types."""
+    action = QtGui.QAction("QtPy", None)
+    action.setShortcut(QtGui.QKeySequence.UnknownKey)
+    action.setShortcuts([QtGui.QKeySequence.UnknownKey])
+    action.setShortcuts(QtGui.QKeySequence.UnknownKey)
+    action.setShortcut(QtCore.Qt.Key.Key_F1)
+    action.setShortcuts([QtCore.Qt.Key.Key_F1])
+    # The following line is wrong even for Qt6 == 6.6:
+    # action.setShortcuts(QtCore.Qt.Key.Key_F1)
+
+
 def test_opengl_imports():
     """
     Test for presence of QOpenGL* classes.

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -187,10 +187,10 @@ def test_QAction_functions(qtbot):
     action.setShortcut(QtGui.QKeySequence.UnknownKey)
     action.setShortcuts([QtGui.QKeySequence.UnknownKey])
     action.setShortcuts(QtGui.QKeySequence.UnknownKey)
-    action.setShortcut(QtCore.Qt.Key.Key_F1)
-    action.setShortcuts([QtCore.Qt.Key.Key_F1])
+    action.setShortcut(QtCore.Qt.Key_F1)
+    action.setShortcuts([QtCore.Qt.Key_F1])
     # The following line is wrong even for Qt6 == 6.6:
-    # action.setShortcuts(QtCore.Qt.Key.Key_F1)
+    # action.setShortcuts(QtCore.Qt.Key_F1)
 
 
 def test_opengl_imports():

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -198,7 +198,7 @@ def test_QAction_functions(qtbot):
 
 
 @pytest.mark.skipif(
-    parse(QT_VERSION) < parse('6.5.0'),
+    parse(QT_VERSION) < parse("6.5.0"),
     reason="Qt6 >= 6.5 specific test",
 )
 @pytest.mark.skipif(

--- a/qtpy/tests/test_qtgui.py
+++ b/qtpy/tests/test_qtgui.py
@@ -189,7 +189,8 @@ def test_QAction_functions(qtbot):
     action.setShortcuts(QtGui.QKeySequence.UnknownKey)
     action.setShortcut(QtCore.Qt.Key_F1)
     action.setShortcuts([QtCore.Qt.Key_F1])
-    # The following line is wrong even for Qt6 == 6.6:
+    # The following line is wrong even for Qt6 == 6.6.
+    # Don't test the function with a single `QtCore.Qt.Key` argument.
     # action.setShortcuts(QtCore.Qt.Key_F1)
 
 

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -148,12 +148,28 @@ def test_QMenu_functions(qtbot):
 def test_QToolBar_functions(qtbot):
     """Test `QtWidgets.QToolBar.addAction` compatibility with Qt6 arguments' order."""
     toolbar = QtWidgets.QToolBar()
-    toolbar.addAction("QtPy with a shortcut", QtGui.QKeySequence.UnknownKey)
+    toolbar.addAction("QtPy with a shortcut", QtCore.Qt.Key.Key_F1)
     toolbar.addAction(
         QtGui.QIcon(),
         "QtPy with an icon and a shortcut",
         QtGui.QKeySequence.UnknownKey,
     )
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info[:2] == (3, 7),
+    reason="Stalls on macOS CI with Python 3.7",
+)
+def test_QAction_functions(qtbot):
+    """Test `QtWidgets.QAction.setShortcut` compatibility with Qt6 types."""
+    action = QtWidgets.QAction("QtPy", None)
+    action.setShortcut(QtGui.QKeySequence.UnknownKey)
+    action.setShortcuts([QtGui.QKeySequence.UnknownKey])
+    action.setShortcuts(QtGui.QKeySequence.UnknownKey)
+    action.setShortcut(QtCore.Qt.Key.Key_F1)
+    action.setShortcuts([QtCore.Qt.Key.Key_F1])
+    # The following line is wrong even for Qt6 == 6.6:
+    # action.setShortcuts(QtCore.Qt.Key.Key_F1)
 
 
 @pytest.mark.skipif(

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -117,10 +117,10 @@ def test_QMenu_functions(qtbot):
     window = QtWidgets.QMainWindow()
     menu = QtWidgets.QMenu(window)
     menu.addAction("QtPy")
-    menu.addAction("QtPy with a shortcut", QtGui.QKeySequence.UnknownKey)
+    menu.addAction("QtPy with a Qt.Key shortcut", QtCore.Qt.Key.Key_F1)
     menu.addAction(
         QtGui.QIcon(),
-        "QtPy with an icon and a shortcut",
+        "QtPy with an icon and a QKeySequence shortcut",
         QtGui.QKeySequence.UnknownKey,
     )
     window.show()

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -157,22 +157,6 @@ def test_QToolBar_functions(qtbot):
 
 
 @pytest.mark.skipif(
-    sys.platform == "darwin" and sys.version_info[:2] == (3, 7),
-    reason="Stalls on macOS CI with Python 3.7",
-)
-def test_QAction_functions(qtbot):
-    """Test `QtWidgets.QAction.setShortcut` compatibility with Qt6 types."""
-    action = QtWidgets.QAction("QtPy", None)
-    action.setShortcut(QtGui.QKeySequence.UnknownKey)
-    action.setShortcuts([QtGui.QKeySequence.UnknownKey])
-    action.setShortcuts(QtGui.QKeySequence.UnknownKey)
-    action.setShortcut(QtCore.Qt.Key.Key_F1)
-    action.setShortcuts([QtCore.Qt.Key.Key_F1])
-    # The following line is wrong even for Qt6 == 6.6:
-    # action.setShortcuts(QtCore.Qt.Key.Key_F1)
-
-
-@pytest.mark.skipif(
     PYQT5 and PYQT_VERSION.startswith("5.9"),
     reason="A specific setup with at least sip 4.9.9 is needed for PyQt5 5.9.*"
     "to work with scoped enum access",

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -117,7 +117,7 @@ def test_QMenu_functions(qtbot):
     window = QtWidgets.QMainWindow()
     menu = QtWidgets.QMenu(window)
     menu.addAction("QtPy")
-    menu.addAction("QtPy with a Qt.Key shortcut", QtCore.Qt.Key.Key_F1)
+    menu.addAction("QtPy with a Qt.Key shortcut", QtCore.Qt.Key_F1)
     menu.addAction(
         QtGui.QIcon(),
         "QtPy with an icon and a QKeySequence shortcut",
@@ -148,7 +148,7 @@ def test_QMenu_functions(qtbot):
 def test_QToolBar_functions(qtbot):
     """Test `QtWidgets.QToolBar.addAction` compatibility with Qt6 arguments' order."""
     toolbar = QtWidgets.QToolBar()
-    toolbar.addAction("QtPy with a shortcut", QtCore.Qt.Key.Key_F1)
+    toolbar.addAction("QtPy with a shortcut", QtCore.Qt.Key_F1)
     toolbar.addAction(
         QtGui.QIcon(),
         "QtPy with an icon and a shortcut",


### PR DESCRIPTION
Test `QMenu.addAction` with a shortcut of `Qt.Key` type as well. The argument type causes the following error on `PySide2`:
```plaintext
TypeError: 'PySide2.QtWidgets.QAction.setShortcut' called with wrong argument types:
  PySide2.QtWidgets.QAction.setShortcut(Key)
Supported signatures:
  PySide2.QtWidgets.QAction.setShortcut(PySide2.QtGui.QKeySequence)
```

This is a direct follow-up to #460.