### PR TITLE
PR: Make `QApplication.exec_` a simple alias for `QApplication.exec` (Qt6)

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -79,11 +79,7 @@ elif PYQT6:
         *args,
         **kwargs,
     )
-    QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(
-        QApplication,
-        *args,
-        **kwargs,
-    )
+    QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(
         QMenu,
@@ -149,11 +145,7 @@ elif PYSIDE6:
     )
 
     # Map DeprecationWarning methods
-    QApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(
-        QApplication,
-        *args,
-        **kwargs,
-    )
+    QApplication.exec_ = QApplication.exec
     QDialog.exec_ = lambda self, *args, **kwargs: self.exec(*args, **kwargs)
     QMenu.exec_ = lambda *args, **kwargs: possibly_static_exec(
         QMenu,


### PR DESCRIPTION
See commit message for details. The change is required for Spyder to start with PyQt6/PySide6. Instead of changing `qtpy`, we also could opt for removing the monkey patch of `QApplication` in Spyder: Spyder seems to work without it (However, mind that I haven’t checked beyond “Spyder starts”).

[1] See https://github.com/spyder-ide/spyder/blob/e624b704959c965ce5a83991f9e374a7759dc6cc/spyder/app/utils.py#L302-L314