### PR TITLE
PR: Add `QtCore.Qt.MouseButton.MidButton` alias for Qt6

### DIFF
--- a/qtpy/QtCore.py
+++ b/qtpy/QtCore.py
@@ -87,6 +87,7 @@ elif PYQT6:
 
     # Alias for MiddleButton removed in PyQt6 but available in PyQt5, PySide2 and PySide6
     Qt.MidButton = Qt.MiddleButton
+    Qt.MouseButton.MidButton = Qt.MiddleButton
 
     # Add removed definition for `Qt.ItemFlags` as an alias of `Qt.ItemFlag`
     # passing as default value 0 in the same way PySide6 6.5+ does.
@@ -142,6 +143,7 @@ elif PYSIDE6:
     ) = Qt.BackgroundRole
     Qt.TextColorRole = Qt.ItemDataRole.TextColorRole = Qt.ForegroundRole
     Qt.MidButton = Qt.MiddleButton
+    Qt.MouseButton.MidButton = Qt.MiddleButton
 
     # Map DeprecationWarning methods
     QCoreApplication.exec_ = lambda *args, **kwargs: possibly_static_exec(

--- a/qtpy/tests/test_qtcore.py
+++ b/qtpy/tests/test_qtcore.py
@@ -188,6 +188,9 @@ def test_enum_access():
     )
     assert QtCore.Qt.TextColorRole == QtCore.Qt.ItemDataRole.TextColorRole
     assert QtCore.Qt.MidButton == QtCore.Qt.MouseButton.MiddleButton
+    assert (
+        QtCore.Qt.MouseButton.MidButton == QtCore.Qt.MouseButton.MiddleButton
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
If QtCore.Qt.MidButton works with QtPy and Qt6, then QtCore.Qt.MouseButton.MidButton is expected to work as well.