### PR TITLE
Add `QT_VERSION` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ default unless you set the `QT_API` environment variable.
 * `pyqt6` (to use PyQt6).
 * `pyside6` (to use PySide6).
 
+Alternatively the `QT_VERSION` environment variable can be used with the following values:
+
+* `qt5` (to use PyQt5 or PySide2).
+* `qt6` (to use PyQt6 or PySide6).
 
 ### Module aliases and constants
 

--- a/qtpy/tests/test_main.py
+++ b/qtpy/tests/test_main.py
@@ -66,6 +66,34 @@ def assert_pyqt6():
     assert os.environ["QT_API"] == "pyqt6"
 
 
+def assert_qt5():
+    try:
+        import PyQt5
+    except ImportError:
+        try:
+            import PySide2
+        except ImportError:
+            pytest.fail("No Qt5 API available.")
+        else:
+            assert_pyside2()
+    else:
+        assert_pyqt5()
+
+
+def assert_qt6():
+    try:
+        import PyQt6
+    except ImportError:
+        try:
+            import PySide6
+        except ImportError:
+            pytest.fail("No Qt6 API available.")
+        else:
+            assert_pyside6()
+    else:
+        assert_pyqt6()
+
+
 def test_qt_api():
     """
     If QT_API is specified, we check that the correct Qt wrapper was used
@@ -140,3 +168,16 @@ else:
     raise AssertionError('QtPy imported despite bad QT_API')
 """
     subprocess.check_call([sys.executable, "-Oc", cmd], env=env)
+
+
+def test_qt_version():
+    """
+    If QT_VERSION is specified, check that one of the correct Qt wrappers was used
+    """
+
+    QT_VERSION = os.environ.get("QT_VERSION", "").lower()
+
+    if QT_VERSION == "qt5":
+        assert_qt5()
+    elif QT_VERSION == "qt6":
+        assert_qt6()


### PR DESCRIPTION
This PR adds the option to specify the Qt version qtpy will use via the `QT_VERSION` environment variable and should resolve #476.

If the `QT_VERSTION` but not the `QT_API` environment variable is set, the `API` is selected based on `QT_VERSTION` (and follows the usual order `PyQt5` -> `PySide2` -> `PyQt6` -> `PySide6` if a binding is not installed). If both environment variables are set, `QT_API` takes precedence. If the version cannot be satisfied or the environment variables are incompatible warnings are triggered.

Please have an extra eye on the test when reviewing as I am not perfectly sure it will behave correctly in the CI environment.

