### PR TITLE
Replace Quansight logo by CZI one in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Everyone is welcome to contribute! See our [Contributing guide](CONTRIBUTING.md)
 QtPy is funded thanks to the generous support of
 
 
-[![Quansight](https://user-images.githubusercontent.com/16781833/142477716-53152d43-99a0-470c-a70b-c04bbfa97dd4.png)](https://www.quansight.com/)[![Numfocus](https://i2.wp.com/numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png?fit=320%2C148&ssl=1)](https://numfocus.org/)
+[![Chan Zuckerberg Initiative](https://raw.githubusercontent.com/spyder-ide/spyder/master/img_src/czi.png)](https://chanzuckerberg.com/)[![Numfocus](https://i2.wp.com/numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png?fit=320%2C148&ssl=1)](https://numfocus.org/)
 
 and the donations we have received from our users around the world through [Open Collective](https://opencollective.com/spyder/):
 


### PR DESCRIPTION
This is because Quansight is no longer one of the main sponsors of this project.