### PR TITLE
Address a PySide6 incompatibility with QTextEdit

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -165,6 +165,14 @@ elif PYSIDE6:
     if parse(_qt_version) > parse("6.3"):
         QFileDialog.Options = lambda value=0: QFileDialog.Option(value)
 
+    # https://github.com/jupyter/qtconsole/issues/624
+    if parse(_qt_version) >= parse("6.8.0"):
+
+        def setExtraSelections(self, selections):
+            self.selections = selections
+
+        QTextEdit.setExtraSelections = setExtraSelections
+
 
 if PYSIDE2 or PYSIDE6:
     # Make PySide2/6 `QFileDialog` static methods accept the `directory` kwarg as `dir`

--- a/qtpy/tests/test_qtwidgets.py
+++ b/qtpy/tests/test_qtwidgets.py
@@ -30,6 +30,9 @@ def test_qtextedit_functions(qtbot, pdf_writer):
     print_device, output_path = pdf_writer
     textedit_widget.print_(print_device)
     assert output_path.exists()
+    # https://github.com/jupyter/qtconsole/issues/624
+    assert QtWidgets.QTextEdit.setExtraSelections
+    textedit_widget.setExtraSelections([])
 
 
 def test_qlineedit_functions():


### PR DESCRIPTION
- [x] Tested against Conda-forge
- [ ] Tested against pypi -- actually pypi doesn't recreate this... 6.8.0.1 does, but the recently released 6.8.0.2 does not.

Closes https://github.com/jupyter/qtconsole/issues/624

Output from conda-forge test when the patch isnt' applied.
```
============================================ test session starts =============================================
platform linux -- Python 3.10.14, pytest-8.3.3, pluggy-1.5.0 -- /home/mark/miniforge3/envs/dev/bin/python3.10
cachedir: .pytest_cache
PySide6 6.8.0 -- Qt runtime 6.8.0 -- Qt compiled 6.8.0

PyQt5: not installed
PySide2: not installed
PyQt6: not installed
PySide6: PySide: 6.8.0 - Qt: 6.8.0

rootdir: /home/mark/git/qtpy
configfile: pytest.ini
plugins: timeout-2.3.1, xdist-3.6.1, time-machine-2.16.0, forked-1.6.0, anyio-4.6.2.post1, qt-4.4.0, env-1.1.5, cov-5.0.0
collected 16 items

qtpy/tests/test_qtwidgets.py::test_qtextedit_functions FAILED                                          [  6%]

================================================== FAILURES ==================================================
__________________________________________ test_qtextedit_functions __________________________________________

qtbot = <pytestqt.qtbot.QtBot object at 0x714cd78a6020>
pdf_writer = (<PySide6.QtGui.QPdfWriter(0x57c8c8e05790) at 0x714cd78e9e00>, PosixPath('test.pdf'))

    def test_qtextedit_functions(qtbot, pdf_writer):
        """Test functions mapping for QtWidgets.QTextEdit."""
        assert QtWidgets.QTextEdit.setTabStopWidth
        assert QtWidgets.QTextEdit.tabStopWidth
        assert QtWidgets.QTextEdit.print_
        textedit_widget = QtWidgets.QTextEdit(None)
        textedit_widget.setTabStopWidth(90)
        assert textedit_widget.tabStopWidth() == 90
        print_device, output_path = pdf_writer
        textedit_widget.print_(print_device)
        assert output_path.exists()
        # https://github.com/jupyter/qtconsole/issues/624
        assert QtWidgets.QTextEdit.setExtraSelections
>       textedit_widget.setExtraSelections([])
E       AttributeError: type object 'PySide6.QtWidgets.QTextEdit' has no attribute 'ExtraSelection'. Did you mean: 'extraSelections'?

qtpy/tests/test_qtwidgets.py:35: AttributeError
-------------------------------------------- Captured Qt messages --------------------------------------------
QtWarningMsg: Could not find the Qt platform plugin "wayland" in ""
============================================ slowest 10 durations ============================================
0.15s setup    qtpy/tests/test_qtwidgets.py::test_qtextedit_functions
0.04s call     qtpy/tests/test_qtwidgets.py::test_qtextedit_functions
0.00s teardown qtpy/tests/test_qtwidgets.py::test_qtextedit_functions
========================================== short test summary info ===========================================
FAILED qtpy/tests/test_qtwidgets.py::test_qtextedit_functions - AttributeError: type object 'PySide6.QtWidgets.QTextEdit' has no attribute 'ExtraSelection'. Did you mean: 'extraSelections'?
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================= 1 failed in 0.56s ==============================================
```