### PR TITLE
PR: Ignore PySide6 `QSqlDatabase.exec` `DeprecationWarning`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ addopts = --durations=10 -v -r a --color=yes --code-highlight=yes --strict-confi
 empty_parameter_set_mark = fail_at_collect
 filterwarnings =
     error
+    ignore:.*QSqlDatabase\.exec\(:DeprecationWarning
 log_auto_indent = True
 log_level = INFO
 minversion = 6.0


### PR DESCRIPTION
When running the package tests with PySide 6, the tests fail because PySide 6 gives a DeprecationWarning, and the pytest.ini settings turn this into an error.  This PR ignores that specific error.

I tried using a `warnings.catch_warnings()` block in `qtpy/QtSql.py` around the deprecated functions, but pytest seems to ignore this.  It might be worth adding such a block anyway.