### PR TITLE
PR: Constraint pytest-qt to 4.4.0 (<4.5.0) when testing PySide2 (CI)

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -6,6 +6,11 @@ eval "$(conda shell.bash hook)"
 BINDING=$(echo "$1" | tr '[:lower:]' '[:upper:]')
 QT_VERSION_VAR=${BINDING}_QT_VERSION
 
+# pytest-qt >=4.5.0 doesn't support PySide2
+if [ "${1}" = "pyside2" ]; then
+    PYTESTQT_VERSION="<4.5.0"
+fi
+
 # pytest-qt >=4 doesn't support Qt <=5.9
 if [ "${!QT_VERSION_VAR:0:3}" = "5.9" ]; then
     PYTESTQT_VERSION="=3.3.0"


### PR DESCRIPTION
Checking PR https://github.com/spyder-ide/qtpy/pull/518 noticed that we are missing to handle the PySide2 drop in the latest pytest-qt version available (4.5.0)