### PR TITLE
Add QWIDGETSIZE_MAX definition for PySide2/6

### DIFF
--- a/qtpy/QtWidgets.py
+++ b/qtpy/QtWidgets.py
@@ -200,6 +200,9 @@ if PYSIDE2 or PYSIDE6:
         "directory",
         "dir",
     )
+
+    # Add missing constant in PySide2/6
+    QWIDGETSIZE_MAX = 16777215
 else:
     # Make PyQt5/6 `QFileDialog` static methods accept the `dir` kwarg as `directory`
     QFileDialog.getExistingDirectory = static_method_kwargs_wrapper(

--- a/tests/test_qtwidgets.py
+++ b/tests/test_qtwidgets.py
@@ -301,3 +301,10 @@ def test_qfiledialog_flags_typedef():
     """
     assert QtWidgets.QFileDialog.Options is not None
     assert QtWidgets.QFileDialog.Options() == QtWidgets.QFileDialog.Option(0)
+
+
+def test_widgetsize_max():
+    """
+    Test existence of `QWIDGETSIZE_MAX` that is not present in PySide2/6
+    """
+    assert QtWidgets.QWIDGETSIZE_MAX


### PR DESCRIPTION
I've kept the implementation as simple as possible. Another option, maybe more readable, is `(1 << 24) - 1`, which is the same value used here ([ref](https://github.com/qt/qtbase/blob/264b97fc9e4c957b014f2da35c1caad28ebc3c99/src/widgets/kernel/qwidget.h#L917)).

Closes #493